### PR TITLE
Update path information for package bundling

### DIFF
--- a/docs/publishing.Rmd
+++ b/docs/publishing.Rmd
@@ -18,7 +18,7 @@ learnr::run_tutorial("slidy", package = "learnr")
 
 To bundle a tutorial into an R package and make it available for running via the `run_tutorial` function you should:
 
-1. Create a `tutorials` directory within the `inst` sub-directory of your package and then create a directory for your tutorial there (e.g. `inst/tutorials/hello`, `inst/tutorials/slidy`, etc.).
+1. Create a `tutorials` directory within your package and then create a directory for your tutorial there (e.g. `tutorials/hello`, `tutorials/slidy`, etc.).
 
 2. Render your tutorial .Rmd to .html and include the rendered HTML in your R package (this will happen automatically during development & preview of the tutorial, you just need to be sure to include the .html file within the R package when you build it).
 


### PR DESCRIPTION
Tiny modification of the description on how how to bundle tutorials using packages. The original description included the `inst` sub-directory. However, `learnr::run_tutorial("mytutorial", package = "mypackage")` won't work this way since `inst` is not part of the `system.file` call :

    > run_tutorial
    function (name, package, shiny_args = NULL) 
    {
        tutorial_path <- system.file("tutorials", name, package = package)

In order to work properly, you need to store your tutorial directories directly underneath the `tutorials` directory.