### PR TITLE
fix diagnostics comma false-positive

### DIFF
--- a/inst/lib/tutorial/tutorial-diagnostics.js
+++ b/inst/lib/tutorial/tutorial-diagnostics.js
@@ -126,7 +126,7 @@ var TutorialDiagnostics = function(tutorial) {
 
     // remove whitespace, comments (not relevant for syntax diagnostics)
     tokens = tokens.filter(function(token) {
-      return token.type !== "comment" && !/\s+/.test(token.value);
+      return token.type !== "comment" && !/^\s+$/.test(token.value);
     });
 
     // state related to our simple diagnostics engine
@@ -172,6 +172,7 @@ var TutorialDiagnostics = function(tutorial) {
       }
 
       if (i > 0) {
+
         var lhs = tokens[i - 1];
         var rhs = tokens[i];
         var bracket = bracketStack[bracketStack.length - 1] || {};

--- a/sandbox/sandbox.Rmd
+++ b/sandbox/sandbox.Rmd
@@ -169,6 +169,16 @@ quiz(
 )
 ```
 
+## diagnostics buglet
+
+```{r diagnostics-comma, exercise=TRUE}
+# a false 'unexpected comma' diagnostic was printed at the end of line 4 below
+GapMinderPlot(
+  LifeExpectency, 
+  countries = c("Germany", "United States", "New Zealand", "China",
+                 "India", "Japan"))
+GapMinderPlot(LifeExpectency)
+```
 
 
 


### PR DESCRIPTION
When producing diagnostics for user code, we attempt to strip out comments and whitespace-only tokens (as they are not relevant to the diagnostics engine). Unfortunately, we were over-aggressively stripping tokens that contained any whitespace when the intention was to strip only whitespace-only tokens.

Closes #95.