### PR TITLE
Use the html4 output format instead of the default html5 in Pandoc 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,49 @@
+learnr 0.9.0.9000
+===========
+
+* Fixed a compability issue, so that existing tutorials don't break when using Pandoc 2.0. ([#130](https://github.com/rstudio/learnr/pull/130))
+
+learnr 0.9.0
+===========
+
+@ commit [#14413cc](https://github.com/rstudio/learnr/commit/14413cc7ea20fa3b5938b29fab2b01282e6f0c1f)
+
+learnr 0.8.0
+===========
+
+@ commit [#eeae534](https://github.com/rstudio/learnr/commit/eeae534fa792dcd369075a90b59b042ad26f945f)
+
+learnr 0.7.0
+===========
+
+@ commit [#b71c637](https://github.com/rstudio/learnr/commit/b71c637cb0b1e0cb817e8e0c2fa56a4fcabd58dd)
+
+learnr 0.6.0
+===========
+
+@ commit [#55c33cf](https://github.com/rstudio/learnr/commit/55c33cf616d3259c508ae234d301964c599a3039)
+
+learnr 0.5.0
+===========
+
+@ commit [#a853163](https://github.com/rstudio/learnr/commit/a8531633f38c13333da6e1c76c6cb6c720e299dd)
+
+learnr 0.4.0
+===========
+
+@ commit [#3339f8a](https://github.com/rstudio/learnr/commit/3339f8aaa2d0402622b1881aa42fcc78ea87db51)
+
+learnr 0.3.0
+===========
+
+@ commit [#9cd0082](https://github.com/rstudio/learnr/commit/9cd00828bfa2429d88ad9efdbd51ad8475a6efb2)
+
+learnr 0.2.0
+===========
+
+@ commit [#a81a694](https://github.com/rstudio/learnr/commit/a81a69498823d860f54c153128719e280de3d831)
+
+learnr 0.1.0
+===========
+
+init commit! [#e2dbb20](https://github.com/rstudio/learnr/commit/e2dbb20d8fb7208cffcb339ea0fc5a8c9c45adb5)

--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -98,9 +98,10 @@ tutorial <- function(fig_width = 6.5,
   
   # knitr and pandoc options
   knitr_options <- knitr_options_html(fig_width, fig_height, fig_retina, keep_md = FALSE , dev)
-  pandoc_options <- pandoc_options(to = "html",
-                                   from = from_rmarkdown(fig_caption, md_extensions),
-                                   args = args)
+  pandoc_options <- pandoc_options(to = "html4",
+    from = from_rmarkdown(fig_caption, md_extensions),
+    args = args,
+    ext = ".html")
   
   # set 1000 as the default maximum number of rows in paged tables
   knitr_options$opts_chunk$max.print <- 1000


### PR DESCRIPTION
This is basically a rip off of rstudio/flexdashboard#150