### PR TITLE
Version bump to 0.9.1: ready to release to CRAN when merged

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: learnr
 Type: Package
 Title: Interactive Tutorials for R
-Version: 0.9
+Version: 0.9.1
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person(family = "RStudio, Inc.", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-learnr 0.9.0.9000
+learnr 0.9.1
 ===========
 
 * Fixed a compability issue, so that existing tutorials don't break when using Pandoc 2.0. ([#130](https://github.com/rstudio/learnr/pull/130))


### PR DESCRIPTION
I've ran the examples in the [examples directory](https://github.com/rstudio/learnr/tree/master/examples/) under Pandoc 1.9 and 2.0. There was no difference.

I've also looked at the code changes between the last version (the first time that `learnr` was released to CRAN), that I tagged here (14413cc). They are really very minor, so I don't think any extra testing is necessary.

Finally, I did `devtools::check()` as CRAN and successfully uploaded the new source package to r-hub.

@jjallaire, if you agree, I can release learnr 0.9.1 to CRAN as soon as this is merged to master. Once CRAN accepts it, I'll tag the current commit as well. (Here's the release checklist I came up with: https://github.com/rstudio/learnr/issues/131)