### PR TITLE
Display full HTML messages if provided by the `incorrect` or the `correct` args to `question() `

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 learnr 0.9.2
 ===========
 
-* Improved documentation for deploying `learnr` tutorials in Shiny Server. ([142](https://github.com/rstudio/learnr/issues/142))
+* Fixed [#136](https://github.com/rstudio/learnr/issues/136) by displaying full HTML messages (rather than just the text) if provided by the `incorrect` or the `correct` args to `question()`. ([#146](https://github.com/rstudio/learnr/pull/146))
+
+* Improved documentation for deploying `learnr` tutorials in Shiny Server. ([#142](https://github.com/rstudio/learnr/issues/142))
 
 * Fixed a highlight.js issue from rmarkdown 1.8. ([#133](https://github.com/rstudio/learnr/issues/133))
 

--- a/inst/htmlwidgets/quiz.js
+++ b/inst/htmlwidgets/quiz.js
@@ -57,7 +57,7 @@ HTMLWidgets.widget({
             
             // look for custom messages
             var msg_class = correct ? '.correct' : '.incorrect';
-            var message = $(el).find('.responses').children(msg_class).children('div').text();
+            var message = $(el).find('.responses').children(msg_class).children('div').html();
             var messages = $(el).find('.answers').children(msg_class + '[data-message]');
             messages.each(function() {
               if ($(this).children('input').is(':checked')) {


### PR DESCRIPTION
This was a quick fix on the JS side: essentially grab the .html() provided by the `incorrect` (and the`correct`) arguments to `question()`. Previously, we were grabbing the .text(), which stripped the html rich formatting when provided.

@jjallaire, this seemed like low hanging fruit for this release. Let me know if you think that it risks regression or anything else I might have overlooked.

Closes #136.