### PR TITLE
Fix 500 errors when reloading tutorial

### DIFF
--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -1,7 +1,6 @@
 
 
 register_http_handlers <- function(session, metadata) {
-  message("Got to session", session$token)
   # parent environment for completions (see discussion in setup_exercise_handler
   # for why this is chosen as the completion/execution parent)
   server_envir <- parent.env(parent.env(parent.frame()))
@@ -221,6 +220,7 @@ register_http_handlers <- function(session, metadata) {
     
   }))
   
+  session$sendCustomMessage("isTutorialReady", "true")
 }
 
 

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -1,7 +1,7 @@
 
 
 register_http_handlers <- function(session, metadata) {
-  
+  message("Got to session", session$token)
   # parent environment for completions (see discussion in setup_exercise_handler
   # for why this is chosen as the completion/execution parent)
   server_envir <- parent.env(parent.env(parent.frame()))

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -220,7 +220,9 @@ register_http_handlers <- function(session, metadata) {
     
   }))
   
-  session$sendCustomMessage("isTutorialReady", "true")
+  # this is a "bat signal" to let the JS side know that the Shiny
+  # server is ready to handle http requests
+  session$sendCustomMessage("tutorial_isServerAvailable", "true")
 }
 
 

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1607,9 +1607,17 @@ Tutorial.prototype.$initializeClientState = function(client_state) {
 
 
 /* Server initialization */
+var isTutorialReady = false;
+Shiny.addCustomMessageHandler("isTutorialReady", function(message) {
+  console.log("message: " + message);
+  if (message === "true") isTutorialReady = true;
+})
 
 Tutorial.prototype.$isServerAvailable = function() {
-  return typeof ((Shiny || {}).shinyapp || {}).config !== "undefined";
+  // receive message tutorial.ready from the R side
+  return(isTutorialReady)
+  
+  // return typeof ((Shiny || {}).shinyapp || {}).config !== "undefined";
 }
 
 Tutorial.prototype.$initializeServer = function() {
@@ -1628,6 +1636,7 @@ Tutorial.prototype.$initializeServer = function() {
     }
     
     // wait for shiny config to be available (required for $serverRequest)
+    console.log("isTutorialReady: " + isTutorialReady);
     if (thiz.$isServerAvailable()) {
       thiz.$logTiming("server-available");
       thiz.$serverRequest("initialize", { location: window.location }, 
@@ -1639,6 +1648,8 @@ Tutorial.prototype.$initializeServer = function() {
             thiz.$restoreState(objects);
           });
         },
+        // remove this once we know our fix works (the responseText has changed from
+        // 'attempt to apply non-function' to the sanitized version by default)
         function (jqXHR) {
           // look for standard error indicating shiny server is not quite ready
           if ((jqXHR.status == 500) && (jqXHR.responseText == "ERROR: attempt to apply non-function" )) {


### PR DESCRIPTION
We do this by allowing `$serverRequest()` calls only after the Shiny server has been fully initialized; our method to guarantee this for `learnr` is to send a custom message at the end of the `register_http_handlers()` function (which is in R), that works as a "bat signal" for the JS side to know when to proceed with calls to `$serverRequest()`.