### PR TITLE
Fix #154: pandoc warning during exercise knit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+learnr 0.9.3
+===========
+
+* Fixed a spurious console warning when running exercises using Pandoc 2.0. ([#154](https://github.com/rstudio/learnr/issues/154))
+
 learnr 0.9.2
 ===========
 

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -205,7 +205,8 @@ evaluate_exercise <- function(exercise, envir) {
     knitr = knitr_options,
     pandoc = NULL,
     base_format = rmarkdown::html_fragment(
-                    df_print = exercise$options$exercise.df_print
+                    df_print = exercise$options$exercise.df_print,
+                    pandoc_args = c("--metadata", "pagetitle=PREVIEW")
                   )
   )
   


### PR DESCRIPTION
Fixes this warning:

```
[WARNING] This document format requires a nonempty <title> element.
  Please specify either 'title' or 'pagetitle' in the metadata.
  Falling back to 'exercise.knit.utf8'
```

Tested under Pandoc 2.0.4 and 1.19.2.1, on Mac.