### PR TITLE
Add `envir_prep` to checker function call

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -52,14 +52,11 @@ setup_exercise_handler <- function(exercise_rx, session) {
       else
         evaluator_factory <- inline_evaluator
     }
-    
-    # create a new environment parented by the global environment 
-    envir <- new.env(parent = globalenv())
-    
+
+    # create a new environment parented by the global environment
     # transfer all of the objects in the server_envir (i.e. setup and data chunks)
-    for (object in ls(envir = server_envir))
-      envir[[object]] <- server_envir[[object]]
-    
+    envir <- twin_env(server_envir, parent = globalenv())
+
     # create exercise evaluator
     evaluator <- evaluator_factory(evaluate_exercise(exercise, envir), timelimit)
     
@@ -107,7 +104,10 @@ setup_exercise_handler <- function(exercise_rx, session) {
 
 # evaluate an exercise and return a list containing output and dependencies
 evaluate_exercise <- function(exercise, envir) {
-  
+
+  # capture a copy of the envir before any execution is done
+  envir_prep <- twin_env(envir)
+
   # see if we need to do code checking
   if (!is.null(exercise$code_check) && !is.null(exercise$options$exercise.checker)) {
     
@@ -121,7 +121,8 @@ evaluate_exercise <- function(exercise, envir) {
       solution_code = exercise$solution,
       check_code = exercise$code_check,
       envir_result = NULL,
-      evaluate_result = NULL
+      evaluate_result = NULL,
+      envir_prep = envir_prep
     )
     
     # if it's an 'incorrect' feedback result then return it
@@ -263,7 +264,8 @@ evaluate_exercise <- function(exercise, envir) {
     solution_code = exercise$solution,
     check_code = exercise$check,
     envir_result = envir,
-    evaluate_result = evaluate_result
+    evaluate_result = evaluate_result,
+    envir_prep = envir_prep
   )
   
   # validate the feedback

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,3 +17,12 @@ is_localhost <- function(location) {
   else
     FALSE
 }
+
+
+# Create an new, 'twin' environment with the same objects and same parent.
+twin_env <- function(envir, parent = parent.env(envir)) {
+  new_envir <- new.env(parent = parent)
+  for (object in ls(envir = envir))
+    new_envir[[object]] <- envir[[object]]
+  new_envir
+}

--- a/docs/exercises.Rmd
+++ b/docs/exercises.Rmd
@@ -203,13 +203,17 @@ What the code within the "-check" chunk actually does will vary depending on whi
 </tr>
 <tr class="odd">
 <td><code>envir_result</code></td>
-<td>The R environment after the execution of the chunk.</td>
+<td>The R environment <b>after</b> the execution of the chunk.</td>
 </tr>
 <tr class="even">
 <td><code>evaluate_result</code></td>
 <td>The return value from the <a href="https://www.rdocumentation.org/packages/evaluate/topics/evaluate"><code>evaluate::evaluate</code></a> function.</td>
 </tr>
-<tr class="pdd">
+<tr class="odd">
+<td><code>envir_prep</code></td>
+<td>A copy of the R environment <b>before</b> the execution of the chunk.</td>
+</tr>
+<tr class="even">
 <td><code>...</code></td>
 <td>Unused (include for compatibility with parameters to be added in the future)</td>
 </tr>
@@ -306,4 +310,3 @@ The following demonstrates setting a 10 second time limit as a global option, do
 <script type="text/javascript">loadSnippet('exercisetimelimit')</script>
 
 Since tutorials are a highly interactive format you should in general be designing exercises that take no longer than 5 or 10 seconds to execute. Correspondingly, the default value for `tutorial.exercise.timelimit` if not otherwise specified is 30 seconds. 
-

--- a/docs/snippets/exercisefeedback.md
+++ b/docs/snippets/exercisefeedback.md
@@ -1,5 +1,5 @@
 ```r
-checker <- function(label, user_code, check_code, envir_result, evaluate_result, ...) {
+checker <- function(label, user_code, solution_code, check_code, envir_result, evaluate_result, envir_prep, ...) {
   list(message = "Great job!", correct = TRUE, location = "append")
 }
 ```

--- a/docs/snippets/exercisefeedback.md
+++ b/docs/snippets/exercisefeedback.md
@@ -1,5 +1,14 @@
 ```r
-checker <- function(label, user_code, solution_code, check_code, envir_result, evaluate_result, envir_prep, ...) {
+checker <- function(
+  label,
+  user_code,
+  solution_code,
+  check_code,
+  envir_result,
+  evaluate_result,
+  envir_prep,
+  ...
+) {
   list(message = "Great job!", correct = TRUE, location = "append")
 }
 ```


### PR DESCRIPTION
Fixes #163

Submits a copy of the exercise environment before the submission is rendered.  This gives a fresh environment for the checker to user that contains the setup code. 