### PR TITLE
require R v 3.5.0 due to `deparse(niceNames = TRUE)` in #183

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,8 @@ Description: Create interactive tutorials using R Markdown. Use a combination
 License: Apache License 2.0 | file LICENSE
 URL: https://rstudio.github.io/learnr/
 BugReports: https://github.com/rstudio/learnr/issues
+Depends:
+  R (>= 3.5.0)
 Imports:
   utils,
   parallel,


### PR DESCRIPTION
#183 introduced `deparse(..., niceNames = TRUE)` which is a new feature of R 3.5.0. [R 3.5.0 Changelog](https://cran.rstudio.com/bin/windows/base/NEWS.R-3.5.1.html)

@jjallaire Any reason why not to enforce a minimum version of 3.5? Or is there a work around for the deparse call?