### PR TITLE
save rmarkdown metadata information using dput vs deparse

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -27,14 +27,21 @@ initialize_tutorial <- function() {
   
     # session initialization (forward tutorial metadata)
     rmarkdown::shiny_prerendered_chunk(
-      'server', 
-      sprintf('learnr:::register_http_handlers(session, metadata = %s)', 
-              deparse(rmarkdown::metadata$tutorial, 
-                      control = c("keepInteger", "niceNames"))),
+      'server',
+      sprintf('learnr:::register_http_handlers(session, metadata = %s)',
+              list_to_string(rmarkdown::metadata$tutorial)),
       singleton = TRUE
     )
     
     # set initialized flag to ensure single initialization
     knitr::opts_knit$set(tutorial.initialized = TRUE)
   }
+}
+
+
+list_to_string <- function(x) {
+  conn <- textConnection("list_to_string", "w")
+  on.exit({close(conn)})
+  dput(x, file = conn)
+  paste0(textConnectionValue(conn), collapse = "")
 }


### PR DESCRIPTION
Only need to cover standard list objects. Will preserve all names and values provided.

``` r
list_to_string <- function(x) {
  conn <- textConnection("list_to_string", "w")
  on.exit({close(conn)})
  dput(x, file = conn)
  paste0(textConnectionValue(conn), collapse = "")
}

x <- list(
  id = list(
    tutorial_id = "toytorial", 
    tutorial_version = "1.0"),
  version = list(
    version_string = "1.0", 
    version_numeric = 1)
)

# Straight deparse drops the integer
deparse(x$version, control = NULL)
#> [1] "list(\"1.0\", 1)"

# The previous code base drops the names
deparse(x$version, control = c("keepInteger"))
#> [1] "list(\"1.0\", 1)"

# My PR
deparse(x$version, control = c("keepInteger", "niceNames"))
#> [1] "list(version_string = \"1.0\", version_numeric = 1)"

# deparse by itself keeps the names (good) but doesn't keep the integer (bad)
deparse(x$version, control = c("keepInteger", "niceNames"))
#> [1] "list(version_string = \"1.0\", version_numeric = 1)"

# use list_to_string to preserve names and values
list_to_string(x)
#> [1] "list(id = list(tutorial_id = \"toytorial\", tutorial_version = \"1.0\"),     version = list(version_string = \"1.0\", version_numeric = 1))"
```

> Created on 2018-09-19 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).