### PR TITLE
override shiny-input-container width to 100%

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 learnr 0.9.2.9000 (unreleased)
 ===========
 
+* Question width will expand to the container width. ([#222](https://github.com/rstudio/learnr/pull/222))
+
 * Added tabset support. ([#219](https://github.com/rstudio/learnr/pull/219) [#213](https://github.com/rstudio/learnr/issues/213))
 
 * Fixed a spurious console warning when running exercises using Pandoc 2.0. ([#154](https://github.com/rstudio/learnr/issues/154))

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.css
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.css
@@ -234,3 +234,8 @@
     display: inline-block;
   }
 }
+
+/* override the width to be 100%, not 300px wide */
+.shiny-input-container:not(.shiny-input-container-inline) {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes: #207

Old:
![Screen Shot 2019-04-10 at 10 30 19 AM](https://user-images.githubusercontent.com/93231/55887555-b5c1e900-5b7b-11e9-8687-fb42c66cdc05.png)

New:
![Screen Shot 2019-04-10 at 10 30 26 AM](https://user-images.githubusercontent.com/93231/55887603-c8d4b900-5b7b-11e9-8a4e-9290d527abb9.png)
