### PR TITLE
Require packrat dev version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,11 @@ Imports:
   knitr (>= 1.14),
   markdown,
   shiny (>= 1.0),
-  rmarkdown (>= 1.12.0)
+  rmarkdown (>= 1.12.0),
+  packrat (>= 0.5.0-7)
 Remotes:
-  rstudio/rmarkdown
+  rstudio/rmarkdown,
+  rstudio/packrat
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1


### PR DESCRIPTION
Fixes #225

Dev packrat that will check for deps within _broken_ rmd files that work correctly within learnr.

(Checks for deps by chunk not by whole tangled R file)

