### PR TITLE
Catch syntax errors in exercises

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ learnr 0.10.0 (unreleased)
 
 * Fixed a spurious console warning when running exercises using Pandoc 2.0. ([#154](https://github.com/rstudio/learnr/issues/154))
 
-* Added a fail-safe to try-catch bad student code that would crash the tutorial. ([@adamblake](https://github.com/adamblake) [#229](https://github.com/rstudio/learnr/issues/229))
+* Added a fail-safe to try-catch bad student code that would crash the tutorial. ([@adamblake](https://github.com/adamblake), [#229](https://github.com/rstudio/learnr/issues/229))
 
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ learnr 0.10.0 (unreleased)
 
 * Fixed a spurious console warning when running exercises using Pandoc 2.0. ([#154](https://github.com/rstudio/learnr/issues/154))
 
+* Added a fail-safe to try-catch bad student code that would crash the tutorial. ([@adamblake](https://github.com/adamblake)) ([#229](https://github.com/rstudio/learnr/issues/229))
+
 
 
 learnr 0.9.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ learnr 0.10.0 (unreleased)
 
 * Fixed a spurious console warning when running exercises using Pandoc 2.0. ([#154](https://github.com/rstudio/learnr/issues/154))
 
-* Added a fail-safe to try-catch bad student code that would crash the tutorial. ([@adamblake](https://github.com/adamblake)) ([#229](https://github.com/rstudio/learnr/issues/229))
+* Added a fail-safe to try-catch bad student code that would crash the tutorial. ([@adamblake](https://github.com/adamblake) [#229](https://github.com/rstudio/learnr/issues/229))
 
 
 

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -13,7 +13,10 @@ inline_evaluator <- function(expr, timelimit) {
       on.exit(setTimeLimit(cpu=Inf, elapsed=Inf, transient=FALSE), add = TRUE);
 
       # execute and capture result
-      result <<- force(expr)
+      result <<- tryCatch(
+        force(expr),
+        error = function(e) error_result(e)
+      )
     },
 
     completed = function() {


### PR DESCRIPTION
Syntax errors will crash the entire app and close the browser. Add a `tryCatch()` to pipe errors to an error result.

See #229 