### PR TITLE
Do not reset question submissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ learnr 0.10.0 (unreleased)
 
 * Missing package dependencies will ask to be installed at tutorial run time. (@isteves, [#253](https://github.com/rstudio/learnr/issues/253))
 
+* When questions are tried again, the existing answer will remain, not forcing the user to restart from scratch. ([#253](https://github.com/rstudio/learnr/issues/253))
+
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ learnr 0.10.0 (unreleased)
 
 * Missing package dependencies will ask to be installed at tutorial run time. (@isteves, [#253](https://github.com/rstudio/learnr/issues/253))
 
-* When questions are tried again, the existing answer will remain, not forcing the user to restart from scratch. ([#253](https://github.com/rstudio/learnr/issues/253))
+* When questions are tried again, the existing answer will remain, not forcing the user to restart from scratch. ([#270](https://github.com/rstudio/learnr/issues/270))
 
 
 ## Bug fixes

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -529,7 +529,9 @@ question_module_server_impl <- function(
   observeEvent(input$action_button, {
 
     if (button_type() == "try_again") {
-      # maintain current submission
+      # maintain current submission / do not randomize answer order
+      # only reset the submitted answers
+      # does NOT reset input$answer
       submitted_answer(NULL)
 
       # submit "reset" to server

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -495,7 +495,10 @@ question_module_server_impl <- function(
     if (is.null(submitted_answer())) {
       # has not submitted, show regular answers
       return(
-        question_ui_initialize(question, input$answer)
+        # if there is an existing input$answer, display it.
+        # if there is no answer... init with NULL
+        # Do not re-render the UI for every input$answer change
+        question_ui_initialize(question, isolate(input$answer))
       )
     }
 

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -495,7 +495,7 @@ question_module_server_impl <- function(
     if (is.null(submitted_answer())) {
       # has not submitted, show regular answers
       return(
-        question_ui_initialize(question, submitted_answer())
+        question_ui_initialize(question, input$answer)
       )
     }
 
@@ -526,7 +526,8 @@ question_module_server_impl <- function(
   observeEvent(input$action_button, {
 
     if (button_type() == "try_again") {
-      init_question(NULL)
+      # maintain current submission
+      submitted_answer(NULL)
 
       # submit "reset" to server
       reset_question_submission_event(


### PR DESCRIPTION
When questions are tried again, the existing answer will remain.

Before this PR, when questions where initialized, they were always initialized with a NULL answer.  If the user was to get the answer wrong and try again, the question would be completely reset.  This PR makes it so that the question is reset, but the existing answer remains.


PR task list:
- [x] Update NEWS
- [NA] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
