### PR TITLE
Text edits to ex-setup-r tutorial

### DIFF
--- a/inst/tutorials/ex-setup-r/ex-setup-r.Rmd
+++ b/inst/tutorials/ex-setup-r/ex-setup-r.Rmd
@@ -14,6 +14,8 @@ tutorial_options(exercise.timelimit = 60)
 
 ## Welcome
 
+This is a demo tutorial. Compare it to the [source code](https://github.com/rstudio/learnr/tree/master/inst/tutorials/ex-setup-r/ex-setup-r.Rmd) that made it.
+
 ### Outline
 
 This tutorial will help you set up your computer to use R. It is for you if you need to:
@@ -21,7 +23,6 @@ This tutorial will help you set up your computer to use R. It is for you if you 
 * Install R on your computer
 * Install the RStudio IDE
 * Install the `tidyverse` R package
-* Learn how to run R code
 
 You can skip this tutorial if you've already done these things.
 
@@ -35,7 +36,6 @@ question("Check all that you have NOT done:",
   answer("installed R on my computer", message = "* Install R"),
   answer("installed the RStudio IDE", message = "* Install RStudio IDE"),
   answer("installed the tidyverse R package", message = "* Install Packages"),
-  answer("used R before", message = "* Run Code"),
   answer("None of the above. I've done them all.", correct = TRUE, message = "You can skip this tutorial!"),
   type = "multiple",
   incorrect = "This tutorial is here to help! To get set up read:"
@@ -59,14 +59,15 @@ quiz(caption = "Quiz - Install R",
   question("Where do you download R?",
     answer("www.rstudio.com/download"),
     answer("[cloud.r-project.org](http://cloud.r-project.org)", correct = TRUE, message = "You can also download R from [cran.r-project.org](http://cran.r-project.org)"),
-    answer("www.r-project.org", message = "Close: www.r-project.org provides a link to one the websites above."),
+    answer("www.r-project.org", message = "Good try, but not exactly. www.r-project.org doesn't provide a download link, but it does provide a link to one the websites above."),
     answer("www.r.com"),
     allow_retry = TRUE
   ),
   question("How often should you update R?",
     answer("Everytime you use it", message = "This will be too often unless you use R very rarely!"),
     answer("About once a year", correct = TRUE, "A new version of R is released about once a year. Update sooner if you encounter a bug that you cannot explain."),
-    answer("Never", message = "A new version of R is released about once a year. I'll assume that you are using the newest version of R, which will be the fastest version with the fewest unexpected behaviors." )
+    answer("Never", message = "A new version of R is released about once a year. I'll assume that you are using the newest version of R, which will be the fastest version with the fewest unexpected behaviors." ),
+    allow_retry = TRUE
   )
 )
 ```


### PR DESCRIPTION
* Adds link to tutorial's source code
* Removes claim that the tutorial has a "Run Code" section (it does not)
* Improves answer messages to Where do you download R? quiz and allows retries

These changes do not merit a NEWS entry or unit tests.
