### PR TITLE
remove pandoc generated warning when evaluating exercises

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@ learnr 0.10.0 (unreleased)
 
 * Replaced references to `checkthat` and `grader` in docs with [gradethis](https://github.com/rstudio-education/gradethis) ([#269](https://github.com/rstudio/learnr/issues/269))
 
+* Removed a warning created by pandoc when evaluating exercises where pandoc was wanting a title or pagetitle. [#303](https://github.com/rstudio/learnr/pull/303)
+
 
 
 learnr 0.9.2

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -275,7 +275,7 @@ evaluate_exercise <- function(exercise, envir) {
     pandoc = NULL,
     base_format = rmarkdown::html_fragment(
                     df_print = exercise$options$exercise.df_print,
-                    pandoc_args = c("--metadata", "pagetitle=PREVIEW")
+                    pandoc_args = c("--metadata", "title=PREVIEW")
                   )
   )
 


### PR DESCRIPTION
Removes warning generated when evaluating exercises:
```
[WARNING] This document format requires a nonempty <title> element.
  Please specify either 'title' or 'pagetitle' in the metadata.
  Falling back to 'exercise.knit.utf8'
```

PR task list:
- [x] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`
