### PR TITLE
Use cran version of sortable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: branch IN (master, travis) AND repo = rstudio/learnr AND type = push
       r: release
       warnings_are_errors: false
-      r_github_packages:
-        - rstudio/sortable
+      r_packages:
+        - sortable
       script:
       - Rscript tools/deploy_tutorials_on_travis.R


### PR DESCRIPTION
The github version is not stable. Use the cran version instead.

PR task list:
- [NA] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`

