### PR TITLE
Use `.on("load", fn)` as `.load(fn)` has been deprecated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ learnr 0.10.0.9000 (unreleased)
 
 * Fixed extra parameter documentation bug. ([#323](https://github.com/rstudio/learnr/pull/323))
 
+* Fixed video initialization error caused by a jQuery version increase in Shiny. ([#326](https://github.com/rstudio/learnr/pull/#326))
+
 
 learnr 0.10.0
 ===========

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -369,7 +369,7 @@ Tutorial.prototype.$injectScript = function(src, onload) {
   script.src = src;
   var firstScriptTag = document.getElementsByTagName('script')[0];
   firstScriptTag.parentNode.insertBefore(script, firstScriptTag);
-  $(script).load(onload);
+  $(script).on("load", onload);
 };
 
 Tutorial.prototype.$debounce = function(func, wait, immediate) {


### PR DESCRIPTION
Fixes #315

PR task list:
- [x] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`
