### PR TITLE
Add session start/stop events

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ learnr 0.10.0.9000 (unreleased)
 
 * `learnr`'s built-in tutorials now come with a description as part of the YAML header, with the intention of this being used in front-end software that catalogues available `learnr` tutorials on the system. ([#312](https://github.com/rstudio/learnr/issues/312))
 
+* Add `session_start` and `session_stop` events. ([#311](https://github.com/rstudio/learnr/pull/328))
+
 ## Bug fixes
 
 * Fixed a bug where broken exercise code created non-"length-one character vector". ([#311](https://github.com/rstudio/learnr/pull/311))

--- a/R/events.R
+++ b/R/events.R
@@ -151,7 +151,17 @@ video_progress_event <- function(session, video_url, time, total_time) {
   save_video_progress(session, video_url, time, total_time)
 }
 
+session_start_event <- function(session) {
+  record_event(session = session,
+               event = "session_start",
+               data = list())
+}
 
+session_stop_event <- function(session) {
+  record_event(session = session,
+               event = "session_stop",
+               data = list())
+}
 
 debug_event_recorder <- function(tutorial_id,
                                  tutorial_version,

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -24,6 +24,11 @@ register_http_handlers <- function(session, metadata) {
       identifiers = identifiers
     )
 
+    # Now that we've initialized the session state, emit the start event
+    record_event(session = session,
+                 event = "session_start",
+                 data = list())
+
     session$userData$learnr_state("initialized")
     # return identifers
     list(

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -25,9 +25,7 @@ register_http_handlers <- function(session, metadata) {
     )
 
     # Now that we've initialized the session state, emit the start event
-    record_event(session = session,
-                 event = "session_start",
-                 data = list())
+    session_start_event(session)
 
     session$userData$learnr_state("initialized")
     # return identifers

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -33,6 +33,15 @@ initialize_tutorial <- function() {
       singleton = TRUE
     )
 
+    # Register session stop handler
+    rmarkdown::shiny_prerendered_chunk(
+      'server',
+      sprintf('session$onSessionEnded(function() {
+        learnr:::record_event(session = session, event = "session_stop", data = list())
+      })'),
+      singleton = TRUE
+    )
+
     # set initialized flag to ensure single initialization
     knitr::opts_knit$set(tutorial.initialized = TRUE)
   }

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -37,7 +37,7 @@ initialize_tutorial <- function() {
     rmarkdown::shiny_prerendered_chunk(
       'server',
       sprintf('session$onSessionEnded(function() {
-        learnr:::record_event(session = session, event = "session_stop", data = list())
+        learnr:::session_stop_event(session)
       })'),
       singleton = TRUE
     )

--- a/docs/publishing.Rmd
+++ b/docs/publishing.Rmd
@@ -261,6 +261,14 @@ The `event` parameter is one of the following values:
 <td>section_skipped</td>
 <td>A section of the tutorial was skipped.</td>
 </tr>
+<tr class="even">
+<td>session_start</td>
+<td>A new session has been initiated</td>
+</tr>
+<tr class="odd">
+<td>session_stop</td>
+<td>A session has been terminated</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/publishing.Rmd
+++ b/docs/publishing.Rmd
@@ -257,6 +257,10 @@ The `event` parameter is one of the following values:
 <td>video_progress</td>
 <td>User watched a segment of a video.</td>
 </tr>
+<tr class="odd">
+<td>section_skipped</td>
+<td>A section of the tutorial was skipped.</td>
+</tr>
 </tbody>
 </table>
 
@@ -289,7 +293,7 @@ The default tutorial and user identifiers are determined as follows:
 <td>tutorial_version</td>
 <td>1.0</td>
 </tr>
-<tr class="add">
+<tr class="odd">
 <td>user_id</td>
 <td>Account name of server user executing the tutorial</td>
 </tr>

--- a/docs/publishing.html
+++ b/docs/publishing.html
@@ -689,6 +689,30 @@ video_progress
 User watched a segment of a video.
 </td>
 </tr>
+<tr class="odd">
+<td>
+section_skipped
+</td>
+<td>
+A section of the tutorial was skipped.
+</td>
+</tr>
+<tr class="even">
+<td>
+session_start
+</td>
+<td>
+A new session has been initiated
+</td>
+</tr>
+<tr class="odd">
+<td>
+session_stop
+</td>
+<td>
+A session has been terminated
+</td>
+</tr>
 </tbody>
 </table>
 <p>The <code>data</code> parameter is an R list which provides additional data that varies depending on which <code>event</code> is being recorded.</p>


### PR DESCRIPTION
Adds `session_start` and `session_stop` events.

I originally hoped to install the session_start handler in `initialize.R` next to the stop handler. Unfortunately, we don't `initialize_session_state` (which is necessary to get the tutorial ID/name/etc) until we run a `session$registerDataObj` handler. I couldn't find a viable way to defer the session start logic until the handler had been run, so I went this route instead. (`later::later` didn't do it late enough).

```
Listening on http://127.0.0.1:6924
com.rstudio.primers.02-vis-basics (1): jeff
event: session_start
com.rstudio.primers.02-vis-basics (1): jeff
event: section_skipped
com.rstudio.primers.02-vis-basics (1): jeff
event: question_submission
com.rstudio.primers.02-vis-basics (1): jeff
event: session_stop
```

PR task list:
- [x] Update NEWS
- NO - Add tests (if possible) -- deemed unfeasible?
- N/A - Update documentation with `devtools::document()`
