### PR TITLE
Fix progressive reveal and Topics with special characters not loading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,9 +13,13 @@ learnr 0.10.0.9000 (unreleased)
 
 * Fixed a bug where broken exercise code created non-"length-one character vector". ([#311](https://github.com/rstudio/learnr/pull/311))
 
-* Fixed extra parameter documentation bug. ([#323](https://github.com/rstudio/learnr/pull/323))
+* Fixed extra parameter documentation bug for CRAN. ([#323](https://github.com/rstudio/learnr/pull/323))
 
 * Fixed video initialization error caused by a jQuery version increase in Shiny. ([#326](https://github.com/rstudio/learnr/pull/#326))
+
+* Fixed progressive reveal bug where the next section would not be displayed unless refreshed. ([#330](https://github.com/rstudio/learnr/pull/330))
+
+* Fixed a bug where topics would not be loaded if they contained non-ascii characters. ([#330](https://github.com/rstudio/learnr/pull/330))
 
 
 learnr 0.10.0

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -320,7 +320,7 @@ $(document).ready(function() {
   function handleLocationHash() {
 
     function findTopicIndexFromHash() {
-      var hash = window.decodeURI(window.location.hash);
+      var hash = window.decodeURIComponent(window.location.hash);
       var topicIndex = 0;
       if (hash.length > 0) {
         $.each(topics, function( ti, t) {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -320,7 +320,7 @@ $(document).ready(function() {
   function handleLocationHash() {
 
     function findTopicIndexFromHash() {
-      var hash = window.location.hash;
+      var hash = window.decodeURI(window.location.hash);
       var topicIndex = 0;
       if (hash.length > 0) {
         $.each(topics, function( ti, t) {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -156,6 +156,9 @@ $(document).ready(function() {
         else {
           scrollLastSectionToView = true;
         }
+        // update UI
+        sectionSkipped([section.jqElement]);
+        // notify server
         tutorial.skipSection(sectionId);
       }
     }


### PR DESCRIPTION
Fixes #320 
Fixes #319 

For #320, there was never a call to notify the js data model that the section had actually been skipped.

For #319, the hash was being returned as `window.encodeURI` output.  By passing it through `window.decodeURI`, it behaves as expected.

<details>
  <summary>File to test with</summary>

```
---
title: "learnr#330"
output:
  learnr::tutorial:
    progressive: true
    allow_skip: true
runtime: shiny_prerendered
---


## Section 1

### Subtopic 1

text

### Subtopic 2.

text

### Subtopic 3

text

## Säction title

### Subtopic 4

text

### Subtopic 5.

text

### Subtopic 6

text

```
</details>

* Should be able to click continue and also view the second section.