### PR TITLE
Remove dead event, clarify Rmd/HTML docs

### DIFF
--- a/docs/publishing.Rmd
+++ b/docs/publishing.Rmd
@@ -20,7 +20,12 @@ To bundle a tutorial into an R package and make it available for running via the
 
 1. Create a `tutorials` directory within the `inst` sub-directory of your package and then create a directory for your tutorial there (e.g. `inst/tutorials/hello`, `inst/tutorials/slidy`, etc.).
 
-2. Render your tutorial .Rmd to .html and include the rendered HTML in your R package (this will happen automatically during development & preview of the tutorial, you just need to be sure to include the .html file within the R package when you build it).
+2. Add the `.Rmd` associated with your tutorial in that directory. (You may see a
+`..._files/` directory or a `.html` file that periodically get generated adjacent
+to your `.Rmd` tutorial. You can safely ignore, delete, or exclude these from your 
+package and from version control. They are temporary artifacts produced while
+rendering the tutorial on your specific system and aren't likely to be 
+portable to other environments.)
 
 Once you've done this users can run your tutorial as follows (note they should be sure to install the **learnr** package before attempting to run the tutorial):
 
@@ -242,14 +247,10 @@ The `event` parameter is one of the following values:
 <td>User requested a hint or solution for an exercise.</td>
 </tr>
 <tr class="even">
-<td>exercise_error</td>
-<td>Error occurred within R code submitted as an answer for an exercise.</td>
-</tr>
-<tr class="odd">
 <td>exercise_submission</td>
 <td>User submitted an answer for an exercise.</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>question_submission</td>
 <td>User submitted an answer for a multiple-choice question.</td>
 </tr>

--- a/docs/publishing.html
+++ b/docs/publishing.html
@@ -13,7 +13,6 @@
 
 <title>Publishing</title>
 
-<script src="site_libs/header-attrs-2.1.1/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/cosmo.min.css" rel="stylesheet" />
@@ -418,14 +417,14 @@ learnr::run_tutorial(&quot;slidy&quot;, package = &quot;learnr&quot;)</code></pr
 <p>To bundle a tutorial into an R package and make it available for running via the <code>run_tutorial</code> function you should:</p>
 <ol style="list-style-type: decimal">
 <li><p>Create a <code>tutorials</code> directory within the <code>inst</code> sub-directory of your package and then create a directory for your tutorial there (e.g. <code>inst/tutorials/hello</code>, <code>inst/tutorials/slidy</code>, etc.).</p></li>
-<li><p>Render your tutorial .Rmd to .html and include the rendered HTML in your R package (this will happen automatically during development &amp; preview of the tutorial, you just need to be sure to include the .html file within the R package when you build it).</p></li>
+<li><p>Add the <code>.Rmd</code> associated with your tutorial in that directory. (You may see a <code>..._files/</code> directory or a <code>.html</code> file that periodically get generated adjacent to your <code>.Rmd</code> tutorial. You can safely ignore, delete, or exclude these from your package and from version control. They are temporary artifacts produced while rendering the tutorial on your specific system and aren’t likely to be portable to other environments.)</p></li>
 </ol>
 <p>Once you’ve done this users can run your tutorial as follows (note they should be sure to install the <strong>learnr</strong> package before attempting to run the tutorial):</p>
 <p>Users would then simply install learnr directly before running your tutorial, for example:</p>
 <pre class="r"><code>install.packages(&quot;learnr&quot;)
 learnr::run_tutorial(&quot;introduction&quot;, package = &quot;mypackage&quot;)</code></pre>
 <div id="exercise-checkers" class="section level3 toc-ignore">
-<h3 class="toc-ignore">Exercise Checkers</h3>
+<h3>Exercise Checkers</h3>
 <p>Note that if your tutorial performs <a href="exercises.html#checking-exercises">exercise checking</a> via an external package then you should be sure to add the package you use for checking as an <code>Imports</code> dependency of your package so it’s installed automatically along with your package.</p>
 <p>Note that it’s likely that the <strong>learnr</strong> package will eventually include or depend on another package that provides checking functions. For the time being though explicit installation of external checking packages is a requirement.</p>
 </div>
@@ -659,21 +658,13 @@ User requested a hint or solution for an exercise.
 </tr>
 <tr class="even">
 <td>
-exercise_error
-</td>
-<td>
-Error occurred within R code submitted as an answer for an exercise.
-</td>
-</tr>
-<tr class="odd">
-<td>
 exercise_submission
 </td>
 <td>
 User submitted an answer for an exercise.
 </td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>
 question_submission
 </td>
@@ -753,7 +744,7 @@ tutorial_version
 1.0
 </td>
 </tr>
-<tr class="add">
+<tr class="odd">
 <td>
 user_id
 </td>


### PR DESCRIPTION
It appears that `exercise_error` in the docs is no longer valid. That string doesn't exist in the code -- at least not anymore. When I submit an invalid exercise, I get an `excercise_submission` event with an `error` field.

e.g. if I submit stop("what") in an exercise, I get this event:

```
com.rstudio.primers.02-vis-basics (1): jeff
event: exercise_submission
$label
[1] "mpg0"
$code
[1] "x <- 1\nx\nstop(\"what\")\n\nflarg"
$output
<div class="alert alert-danger" role="alert">what</div>
$error_message
[1] "what"
$checked
[1] FALSE
$feedback
NULL
```

Also fixes #327