### PR TITLE
Set a content length on session initialization request

### DIFF
--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -251,7 +251,8 @@ internal_external_evaluator <- function(
 #'   the err'ing response
 #' @noRd
 initiate_external_session <- function(pool, url, callback, err_callback){
-  handle <- curl::new_handle(post=1)
+  handle <- curl::new_handle(post=1,
+                             postfieldsize = 0)
 
   done_cb <- function(res){
     id <- NULL

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -84,6 +84,8 @@ test_that("initiate_external_session works", {
 
   expect_equal(failed, FALSE)
   expect_equal(sess_ids, rep("abcd1234", 3))
+
+  expect_equal(srv$reqs[[1]]$req$CONTENT_LENGTH, "0")
 })
 
 test_that("initiate_external_session fails with bad status", {


### PR DESCRIPTION
Some hosting providers will complain about a POST with no content-length.