### PR TITLE
Limit concurrent forks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,17 +6,17 @@ learnr (development version)
 * Renamed the `exercise_submission` event to `exercise_result` and added the following fields: 
   1. `id` - a randombly generated identifier that can be used to align with the associated `exercise_result` event.
   2. `time_elapsed` - the time required to run the exercise (in seconds)
-  3. `timeout_exceeded` - indicates whether the exercise was interrupted due to an exceeded timeout. May be `NA` for some platforms/evaluators if that information is not known or reported.
+  3. `timeout_exceeded` - indicates whether the exercise was interrupted due to an exceeded timeout. May be `NA` for some platforms/evaluators if that information is not known or reported. ([#337](https://github.com/rstudio/learnr/pull/337))
   
 
 ## New features
 
-* Introduced an [experimental](https://www.tidyverse.org/lifecycle/#experimental) function `external_evaluator()` which can be used to define an exercise evaluator that runs on a remote server and is invoked via HTTP. This allows all exercise execution to be performed outside of the Shiny process hosting the learnr document.
-* For the "forked" evaluator (the default used on Linux), add a limit to the number of forked exercises that learnr will execute in parallel. Previously, this was uncapped, which could cause a learnr process to run out of memory when an influx of traffic arrived. The default limit is 3, but it can be configured using the `tutorial.max.forked.procs` option or the `TUTORIAL_MAX_FORKED_PROCS` environment variable.
+* Introduced an [experimental](https://www.tidyverse.org/lifecycle/#experimental) function `external_evaluator()` which can be used to define an exercise evaluator that runs on a remote server and is invoked via HTTP. This allows all exercise execution to be performed outside of the Shiny process hosting the learnr document. ([#345](https://github.com/rstudio/learnr/pull/345))
+* For the "forked" evaluator (the default used on Linux), add a limit to the number of forked exercises that learnr will execute in parallel. Previously, this was uncapped, which could cause a learnr process to run out of memory when an influx of traffic arrived. The default limit is 3, but it can be configured using the `tutorial.max.forked.procs` option or the `TUTORIAL_MAX_FORKED_PROCS` environment variable. ([#353](https://github.com/rstudio/learnr/pull/353))
 
 ## Minor new features and improvements
 
-* Added an `exercise_submitted` event which is fired before evaluating an exercise. This event can be associated with an `exercise_result` event using the randomly generated `id` included in the data of both events.
+* Added an `exercise_submitted` event which is fired before evaluating an exercise. This event can be associated with an `exercise_result` event using the randomly generated `id` included in the data of both events. ([#337](https://github.com/rstudio/learnr/pull/337))
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ learnr (development version)
 ## New features
 
 * Introduced an [experimental](https://www.tidyverse.org/lifecycle/#experimental) function `external_evaluator()` which can be used to define an exercise evaluator that runs on a remote server and is invoked via HTTP. This allows all exercise execution to be performed outside of the Shiny process hosting the learnr document.
+* For the "forked" evaluator (the default used on Linux), add a limit to the number of forked exercises that learnr will execute in parallel. Previously, this was uncapped, which could cause a learnr process to run out of memory when an influx of traffic arrived. The default limit is 3, but it can be configured using the `tutorial.max.forked.procs` option or the `TUTORIAL_MAX_FORKED_PROCS` environment variable.
 
 ## Minor new features and improvements
 

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -68,6 +68,7 @@ forked_evaluator <- function(expr, timelimit, ...) {
           # Then we can't start this job yet.
           print("Delaying exercise execution due to forked proc limits")
           later::later(doStart, 1)
+          return()
         }
 
         # increment our counter of processes

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -73,7 +73,6 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 
           # increment our counter of processes
           running_exercises <<- running_exercises + 1
-          cat("Running ", running_exercises, " exercises now\n")
 
           job <<- parallel::mcparallel(mc.interactive = FALSE, {
 
@@ -106,7 +105,6 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 
           # decrement our counter of processes
           running_exercises <<- running_exercises - 1
-          cat("Finished exercise, now ", running_exercises, "\n")
 
           # return result
           result <<- collect[[1]]
@@ -126,7 +124,6 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 
           # decrement our counter of processes
           running_exercises <<- running_exercises - 1
-          cat("Exercise timed out, now ", running_exercises, "\n")
 
           # return error result
           result <<- error_result(timeout_error_message(), timeout_exceeded = TRUE)

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -143,7 +143,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
   }
 }
 
-forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = 3)
+forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = getOption("tutorial.max.forked.procs", Sys.getenv("TUTORIAL_MAX_FORKED_PROCS", NA)))
 
 #' External execution evaluator
 #'
@@ -154,7 +154,7 @@ forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = 3)
 #' @import curl
 #' @export
 external_evaluator <- function(
-  endpoint = getOption("tutorial.external.host", Sys.getenv("TUTORIAL_external_evaluator_HOST", NA)),
+  endpoint = getOption("tutorial.external.host", Sys.getenv("TUTORIAL_EXTERNAL_EVALUATOR_HOST", NA)),
   max_curl_conns = 50){
 
   internal_external_evaluator(endpoint, max_curl_conns)

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -144,6 +144,9 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 }
 
 forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = getOption("tutorial.max.forked.procs", Sys.getenv("TUTORIAL_MAX_FORKED_PROCS", 3)))
+# Maintain for backwards-compatibility with original implementation in which
+# forked_evaluator was uncapped
+forked_evaluator <- setup_forked_evaluator_factory(max_forked_procs = Inf)
 
 #' External execution evaluator
 #'

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -143,7 +143,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
   }
 }
 
-forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = getOption("tutorial.max.forked.procs", Sys.getenv("TUTORIAL_MAX_FORKED_PROCS", NA)))
+forked_evaluator_factory <- setup_forked_evaluator_factory(max_forked_procs = getOption("tutorial.max.forked.procs", Sys.getenv("TUTORIAL_MAX_FORKED_PROCS", 3)))
 
 #' External execution evaluator
 #'

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -67,7 +67,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           if (running_exercises >= max_forked_procs) {
             # Then we can't start this job yet.
             print("Delaying exercise execution due to forked proc limits")
-            later::later(doStart, 1)
+            later::later(doStart, 0.1)
             return()
           }
 

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -51,7 +51,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
       if (!is.na(remote_host)){
         evaluator_factory <- external_evaluator(remote_host)
       } else if (!is_windows() && !is_macos())
-        evaluator_factory <- forked_evaluator
+        evaluator_factory <- forked_evaluator_factory
       else
         evaluator_factory <- inline_evaluator
     }

--- a/man/external_evaluator.Rd
+++ b/man/external_evaluator.Rd
@@ -6,7 +6,7 @@
 \usage{
 external_evaluator(
   endpoint = getOption("tutorial.external.host",
-    Sys.getenv("TUTORIAL_external_evaluator_HOST", NA)),
+    Sys.getenv("TUTORIAL_EXTERNAL_EVALUATOR_HOST", NA)),
   max_curl_conns = 50
 )
 }


### PR DESCRIPTION
Add a limit to the "forked" evaluator (the default used on Linux) to limit the number of forked exercises that learnr will execute in parallel. Previously, this was uncapped, which could cause a learnr process to run out of memory when an influx of traffic arrived. The default limit is 3, but it can be configured using the `tutorial.max.forked.procs` option or the `TUTORIAL_MAX_FORKED_PROCS` environment variable.