### PR TITLE
Properly enforce timelimits >= 60s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ learnr (development version)
 
 ## Bug fixes
 
+* Properly enforce time limits exceeding 60 seconds. ([#365](https://github.com/rstudio/learnr/pull/365))
 
 learnr 0.10.1
 ===========

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -117,7 +117,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
         }
 
         # hit timeout
-        else if ((Sys.time() - start_time) >= timelimit) {
+        else if (difftime(Sys.time(), start_time, units="secs") >= timelimit) {
 
           # call cleanup hook
           call_hook("oncleanup", default = default_cleanup)


### PR DESCRIPTION
If an exercise had an assigned timelimit of >= 60s, it would never be reaped. This is because by default when you subtract times it becomes a `difftime` object which will be presented in arbitrary units. Around the 60s mark, you can see we switch from:

```
> str(Sys.time() - start_time)
 'difftime' num 58.2525360584259
 - attr(*, "units")= chr "secs"
```

to:

```
> str(Sys.time() - start_time)
 'difftime' num 1.01057458321253
 - attr(*, "units")= chr "mins"
```

When you compare on this time, it compares 1 to your assigned time limit and permits it to continue computing.

We need to force the time comparison into seconds in order to accurately compare to our time limit.