### PR TITLE
Use pool, flag restored events, resolve requests independently

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: learnr
 Type: Package
 Title: Interactive Tutorials for R
-Version: 0.10.1.9002
+Version: 0.10.1.9003
 Authors@R: c(
   person("Barret", "Schloerke", role = c("aut", "cre"), email = "barret@rstudio.com",
         comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ learnr (development version)
 ## Minor new features and improvements
 
 * Added an `exercise_submitted` event which is fired before evaluating an exercise. This event can be associated with an `exercise_result` event using the randomly generated `id` included in the data of both events. ([#337](https://github.com/rstudio/learnr/pull/337))
+* Added a `restore` flag on `exercise_submitted` events which is `TRUE` if the exercise is being restored from a previous execution, or `FALSE` if the exercise is being run interactively.
 
 ## Bug fixes
 

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -177,7 +177,7 @@ internal_external_evaluator <- function(
   initiate = initiate_external_session){
 
   if (is.na(endpoint)){
-    stop("You must specify an endpoint explicitly as a parameter, or via the `tutorial.external.host` option, or the `TUTORIAL_external_evaluator_HOST` environment variable")
+    stop("You must specify an endpoint explicitly as a parameter, or via the `tutorial.external.host` option, or the `TUTORIAL_EXTERNAL_EVALUATOR_HOST` environment variable")
   }
 
   # Trim trailing slash

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -241,7 +241,7 @@ internal_external_evaluator <- function(
           curl::curl_fetch_multi(url, handle = handle, done = done_cb, fail = fail_cb, pool = pool)
 
           poll <- function(){
-            res <- curl::multi_run(timeout = 0)
+            res <- curl::multi_run(timeout = 0, pool = pool)
             if (res$pending > 0){
               later::later(poll, delay = 0.1)
             }

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -343,10 +343,10 @@ initiate_external_session <- function(pool, url, global_setup, retry_count = 0){
       resolve(list(id = id, cookieFile = cookieFile))
     }
 
-    curl::curl_fetch_multi(url, handle = handle, done = done_cb, fail = reject)
+    curl::curl_fetch_multi(url, handle = handle, done = done_cb, fail = reject, pool = pool)
 
     poll <- function(){
-      res <- curl::multi_run(timeout = 0)
+      res <- curl::multi_run(timeout = 0, pool = pool)
       if (res$pending > 0){
         later::later(poll, delay = 0.1)
       }

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -238,7 +238,7 @@ internal_external_evaluator <- function(
             result <<- error_result("Error submitting external exercise. Please try again later")
           }
 
-          curl::curl_fetch_multi(url, handle = handle, done = done_cb, fail = fail_cb)
+          curl::curl_fetch_multi(url, handle = handle, done = done_cb, fail = fail_cb, pool = pool)
 
           poll <- function(){
             res <- curl::multi_run(timeout = 0)

--- a/R/events.R
+++ b/R/events.R
@@ -95,13 +95,15 @@ section_skipped_event <- function(session, sectionId) {
 exercise_submitted_event <- function(session,
                                       id,
                                       label,
-                                      code) {
+                                      code,
+                                      restore) {
   # notify server-side listeners
   record_event(session = session,
                event = "exercise_submitted",
                data = list(label = label,
                            id = id,
-                           code = code))
+                           code = code,
+                           restore = restore))
 
   # TODO: we could save the code for later replay in case the evaluation gets interrupted.
 }

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -76,7 +76,8 @@ setup_exercise_handler <- function(exercise_rx, session) {
       session = session,
       id = ex_id,
       label = exercise$label,
-      code = exercise$code
+      code = exercise$code,
+      restore = exercise$restore
     )
 
     start <- Sys.time()

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -47,7 +47,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
     # get exercise evaluator factory function (allow replacement via global option)
     evaluator_factory <- getOption("tutorial.exercise.evaluator", default = NULL)
     if (is.null(evaluator_factory)) {
-      remote_host <- getOption("tutorial.external.host", Sys.getenv("TUTORIAL_external_evaluator_HOST", NA))
+      remote_host <- getOption("tutorial.external.host", Sys.getenv("TUTORIAL_EXTERNAL_EVALUATOR_HOST", NA))
       if (!is.na(remote_host)){
         evaluator_factory <- external_evaluator(remote_host)
       } else if (!is_windows() && !is_macos())

--- a/docs/publishing.Rmd
+++ b/docs/publishing.Rmd
@@ -198,7 +198,7 @@ The pararmeters provided to the evaluator may be expanded in the future, so cust
 
 ##### External Evalutor
 
-In versions of learnr later than 0.10.1, there is also support for a `external_evaluator`. This evaluator allows exercises to be executed on a remote host rather than on the host running the Shiny process. You can use this evaluator by specifying a `tutorial.external.host` option or setting a `TUTORIAL_external_evaluator_HOST` environment variable. If set, learnr will submit exercises over HTTP to the specified host.
+In versions of learnr later than 0.10.1, there is also support for a `external_evaluator`. This evaluator allows exercises to be executed on a remote host rather than on the host running the Shiny process. You can use this evaluator by specifying a `tutorial.external.host` option or setting a `TUTORIAL_EXTERNAL_EVALUATOR_HOST` environment variable. If set, learnr will submit exercises over HTTP to the specified host.
 
 The given host is expected to fulfill [this OpenAPI specification](openapi/openapi.yaml). In other words, it has two HTTP endpoints:
 

--- a/docs/publishing.html
+++ b/docs/publishing.html
@@ -392,7 +392,7 @@ div.tocify {
         <li>
   <a href="https://github.com/rstudio/learnr">
     <span class="fa fa-github"></span>
-     
+
   </a>
 </li>
       </ul>
@@ -579,7 +579,7 @@ R object to be saved
 <p>The pararmeters provided to the evaluator may be expanded in the future, so custom evaluators should permit additional arguments that have not yet been defined.</p>
 <div id="external-evalutor" class="section level5">
 <h5>External Evalutor</h5>
-<p>In versions of learnr later than 0.10.1, there is also support for a <code>external_evaluator</code>. This evaluator allows exercises to be executed on a remote host rather than on the host running the Shiny process. You can use this evaluator by specifying a <code>tutorial.external.host</code> option or setting a <code>TUTORIAL_external_evaluator_HOST</code> environment variable. If set, learnr will submit exercises over HTTP to the specified host.</p>
+<p>In versions of learnr later than 0.10.1, there is also support for a <code>external_evaluator</code>. This evaluator allows exercises to be executed on a remote host rather than on the host running the Shiny process. You can use this evaluator by specifying a <code>tutorial.external.host</code> option or setting a <code>TUTORIAL_EXTERNAL_EVALUATOR_HOST</code> environment variable. If set, learnr will submit exercises over HTTP to the specified host.</p>
 <p>The given host is expected to fulfill <a href="openapi/openapi.yaml">this OpenAPI specification</a>. In other words, it has two HTTP endpoints:</p>
 <ol style="list-style-type: decimal">
 <li><code>POST /learnr/</code> - Initiate a session</li>

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -168,7 +168,7 @@ test_that("initiate_external_session fails with failed curl", {
   ))
 
   # Start and stop the server as a way to obtain a port number that's likely
-  # inavtive.
+  # inactive.
   srv <- start_server(responses)
   srv$stop()
 

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -32,7 +32,13 @@ start_server <- function(responses){
       # See if this method + path has a defined response
       id <- req_to_id(req)
       if (!is.null(responses[[id]])){
-        return(responses[[id]])
+        res <- responses[[id]]
+        if (is.function(res)){
+          # Invoke
+          return(res())
+        } else {
+          return(res)
+        }
       }
 
       # Otherwise, 404
@@ -88,6 +94,54 @@ test_that("initiate_external_session works", {
   expect_equal(sess_ids, rep("abcd1234", 3))
 
   expect_equal(jsonlite::fromJSON(rawToChar(srv$reqs[[1]]$body)), list(global_setup = ""))
+})
+
+
+test_that("initiate_external_session doesn't wait on all requests", {
+  # We previously used curl::multi_run which, it turns out, waits for ALL
+  # requests in the pool to resolve, not just the handle you provide. So this
+  # test ensures that a single slow request in the pool doesn't slow down other
+  # requests.
+
+  testthat::skip_on_cran()
+
+  responses <- list(`POST /learnr/` = list(
+    status = 200L,
+    headers = list(
+      'Content-Type' = 'application/json'
+    ),
+    body = '{"id": "abcd1234"}'
+  ))
+
+  srv <- start_server(responses)
+  on.exit(srv$stop(), add = TRUE)
+
+  result <- NULL
+  cb <- function(result){
+    result <<- TRUE
+  }
+  err_cb <- function(res){
+    print(res)
+    testthat::fail("Unexpected error from initiate_external_session")
+    result <<- FALSE
+  }
+
+  start <- Sys.time()
+
+  # Trigger a slow (2s) request
+  curl::curl_fetch_multi("http://www.httpbin.org/delay/2", done = function(res){ expect_gt(difftime(Sys.time(), start, units="secs"), 2) }, pool = pool)
+
+  # Initiate a session
+  initiate_external_session(pool, paste0(srv$url, "/learnr/"), "") %>% then(cb, err_cb)
+
+  while(is.null(result)){
+    later::run_now()
+  }
+
+  expect_equal(result, TRUE)
+
+  # Should return before the slow request returns
+  expect_lt(difftime(Sys.time(), start, units="secs"), 2)
 })
 
 test_that("initiate_external_session fails with bad status", {


### PR DESCRIPTION
1. use the curl pool that had been created but was going unused. This will allow us to send more than 6 requests to an external evaluator at once.
2. Includes the `restore` flag on `exercise_submitted` events so that we can differentiate restored from interactive events.
3. Fixes an external evaluator bug in which we were previously waiting for EVERY request to resolve rather than just waiting for a particular request to resolve.

Closes #363 