### PR TITLE
Fix #348: All exercises resolve to complete when one is completed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ learnr (development version)
 
 * Properly enforce time limits and measure exercise execution times that exceed 60 seconds ([#366](https://github.com/rstudio/learnr/pull/366), [#368](https://github.com/rstudio/learnr/pull/368))
 * Fixed unexpected behavior for `question_is_correct.learnr_text()` where `trim = FALSE`. Comparisons will now happen with the original input value, not the `HTML()` formatted answer value. ([#376](https://github.com/rstudio/learnr/pull/376))
+* Fixed exercise progress spinner being prematurely cleared. ([#384](https://github.com/rstudio/learnr/pull/384))
 
 learnr 0.10.1
 ===========

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1400,6 +1400,9 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
 
     renderValue: function renderValue(el, data) {
 
+      // See big comment in showProgress method, below.
+      thiz.$showExerciseProgress(exerciseLabel(el), null, false);
+
       // remove default content (if any)
       this.outputFrame(el).children().not($(el)).remove();
 
@@ -1425,7 +1428,18 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
     },
 
     showProgress: function(el, show) {
-      thiz.$showExerciseProgress(exerciseLabel(el), null, show);
+      if (show) {
+        thiz.$showExerciseProgress(exerciseLabel(el), null, show);
+      } else {
+        // This branch is intentionally empty. You'd expect that we would call
+        //     thiz.$showExerciseProgress(exerciseLabel(el), null, show);
+        // at this time, but we cannot due to a quirk in Shiny. Shiny assumes
+        // that when we receive a new value for one output, then all outputs are
+        // done; this is because all outputs are held and flushed together. I
+        // (jcheng) don't know enough about learnr to know why this assumption
+        // doesn't hold in this case, but it doesn't (issue #348). Instead, we
+        // need to use renderValue as a proxy for showProgress(false).
+      }
     },
 
     outputFrame: function(el) {


### PR DESCRIPTION
Fixes #348.

---

Run the following, click the "Run Code" buttons one after another quickly. The progress spinner on both code chunks clear after 1 second, even though the `two` chunk doesn't complete for a few more seconds.

````
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)
```

```{r one, exercise=TRUE}
Sys.sleep(1); print("DONE!")
```

```{r two, exercise=TRUE}
Sys.sleep(5); print("DONE2!")
```
````
PR task list:
- [x] Update NEWS
- [ ] Add tests (if possible)
- [x] Update documentation with `devtools::document()`
