### PR TITLE
Fix exercises not being restored

### DIFF
--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1593,15 +1593,29 @@ Tutorial.prototype.$restoreState = function(objects) {
   });
 };
 
-
+// submissions is an object where the keys are the submission id, and the values
+// are of this shape:
+// {
+//   type: string,
+//   id: string,
+//   data: {
+//     checked: boolean,
+//     code: string,
+//     feedback: ?,
+//     output: ?
+//   }
+// }
 Tutorial.prototype.$restoreSubmissions = function(submissions) {
 
   // alias this
   var thiz = this;
 
-  for (var i = 0; i < submissions.length; i++) {
+  for (var key in submissions) {
+    if (!submissions.hasOwnProperty(key)) {
+      continue;
+    }
 
-    var submission = submissions[i];
+    var submission = submissions[key];
     var type = submission.type;
     var id = submission.id;
 


### PR DESCRIPTION
Fixes #318. The for-loop in $restoreSubmissions was not being
entered because the `submissions` argument was being treated as an array
when it's actually an object.

## Minimal reproducible example

````
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)
message(getwd())
if (!file.exists("state.rds")) {
  saveRDS(list(), "state.rds")
}
options(tutorial.storage = list(
  # save an arbitrary R object "data" to storage
  save_object = function(tutorial_id, tutorial_version, user_id, object_id, data) {
    cat("SAVE: ", object_id, "\n")
    all <- readRDS("state.rds")
    all[[object_id]] <- data
    saveRDS(all, "state.rds")
  },
  
  # retreive a single R object from storage
  get_object = function(tutorial_id, tutorial_version, user_id, object_id) { 
    cat("GET OBJ: ", object_id, "\n")
    state <- readRDS("state.rds")
    s <- state[[object_id]]
    if (!is.null(s)){
      print("\tFOUND")
    } else {
      print("\tNO")
    }
    s
  },
  
  # retreive a list of all R objects stored
  get_objects = function(tutorial_id, tutorial_version, user_id) { 
    print("GET OBJS")
    readRDS("state.rds")
  },
  
  # remove all stored R objects
  remove_all_objects = function(tutorial_id, tutorial_version, user_id) {
    file.remove("state.rds")
  }
))
```

```{r one, exercise=TRUE}
"hello"
```
````

Change the code in the exercise box, run it, then reload. The exercise is written to state.rds, but the restore doesn't actually work.

The issue was due to a JS type error (expecting an array but being provided with an object).

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
