### PR TITLE
Adds a hook for specifying an alternative to learnr:::evaluate_exercise()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 learnr (development version)
 ===========
 
+
+
 ## Breaking Changes
 
 * Renamed the `exercise_submission` event to `exercise_result` and added the following fields:
@@ -19,6 +21,7 @@ learnr (development version)
 * Added an `exercise_submitted` event which is fired before evaluating an exercise. This event can be associated with an `exercise_result` event using the randomly generated `id` included in the data of both events. ([#337](https://github.com/rstudio/learnr/pull/337))
 * Added a `restore` flag on `exercise_submitted` events which is `TRUE` if the exercise is being restored from a previous execution, or `FALSE` if the exercise is being run interactively.
 * Add `label` field to the `exercise_hint` event to identify for which exercise the user requested a hint. ([#377](https://github.com/rstudio/learnr/pull/377))
+* Add a global option `learnr.alt.evaluator` that will replace the built in `learnr:::evaluate_exercise()` with an alternative, the function named in the string value of the option `learnr.alt.evaluator`.
 
 ## Bug fixes
 

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -65,7 +65,15 @@ setup_exercise_handler <- function(exercise_rx, session) {
     envir <- duplicate_env(server_envir, parent = globalenv())
 
     # create exercise evaluator
-    evaluator <- evaluator_factory(evaluate_exercise(exercise, envir),
+
+    # by default, use learnr's native evaluate exercise
+    evaluate_exercise_fn <- evaluate_exercise # defined below
+    # but allow an alternative exercise evaluator via the option learnr.alt.evaluator
+    alternative_fn_name <- getOption("learnr.alt.evaluator")
+    if (!is.null(alternative_fn_name)) {
+      evaluate_exercise_fn <- eval(parse(text = alternative_fn_name))
+    }
+    evaluator <- evaluator_factory(evaluate_exercise_fn(exercise, envir),
                                    timelimit, exercise, session)
 
     # Create exercise ID to map the associated events.

--- a/man/initialize_tutorial.Rd
+++ b/man/initialize_tutorial.Rd
@@ -8,6 +8,6 @@ initialize_tutorial()
 }
 \description{
 One time initialization of R Markdown extensions required by the
-\pkg{tutor} package. This function is typically called automatically
+\pkg{learnr} package. This function is typically called automatically
 as a result of using exercises or questions.
 }


### PR DESCRIPTION
## Motivation

Per [issue 356](https://github.com/rstudio/learnr/issues/356), this proposed change adds a way to replace the built-in exercise code evaluator (`learnr:::evaluate_exercise`) with one of the tutorial author's choosing. This is accomplished by adding a global option,  `learnr.alt.evaluator` that can be set to a string naming the evaluator to be used.  By default (that is, if  the option `learnr.alt.evaluator` is NULL), the built in code evaluator is used, so there is absolutely no change to the learnr code evaluation process.

Being  able to specify an alternative evaluator allows more seamless parse-time checking and provides a means to evaluate the exercise code while doing the code checking, rather than the method in learnr where the code is evaluated and the results handed off to the checker.

## Structure of change

I attempted to minimize the extent of changes to the code base by using `options()` rather than `tutorialOptions()` to set the name of the alternative evaluator. It would be perhaps more natural to the user to set the  alternative using `tutorialOptions()`, but this requires additional 
 changes to the code base. (And, since `tutorialOptions()` involves knitr hooks, I'm not confident that I would do this properly.)

I do not know enough about the new remote evaluators to determine if there is any impact on that.

## Impact of change

I am already using an alternative evaluator for a large set of tutorials I am developing. The evaluator is published as a package at `github.com/dtkaplan/learnrAlt`.  The evaluator is compatible with the facilities of the `gradethis` package. I cannot predict whether there will be many  people who want to *write* an alternative evaluator, but mine can serve as  a framework for others to work on parse-time checkers or alternative graders. @garrettgman may have some opinion about this.

## Pull Request

* Add an entry to NEWS concisely describing what you changed. DONE.

* Add unit tests in the tests/testthat directory. NOT DONE. But see the test below.

* Run Build->Check Package in the RStudio IDE, or `devtools::check()`, to make sure your change did not add any messages, warnings, or errors. DONE

## Minimal reproducible example

See the attached learnr Rmd file, which contains a trivial alternative evaluator. For a complete working evaluator, see the `github.com/dtkaplan/learnrAlt` repository.
[alt-eval.Rmd.zip](https://github.com/rstudio/learnr/files/4771823/alt-eval.Rmd.zip)



