### PR TITLE
temp folder for tutorial output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ learnr (development version)
 ## Bug fixes
 
 * Properly enforce time limits and measure exercise execution times that exceed 60 seconds ([#366](https://github.com/rstudio/learnr/pull/366), [#368](https://github.com/rstudio/learnr/pull/368))
+* Render tutorial in a temp directory to avoid errors due to write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
 
 learnr 0.10.1
 ===========

--- a/R/run.R
+++ b/R/run.R
@@ -51,13 +51,17 @@ run_tutorial <- function(name = NULL, package = NULL, shiny_args = NULL) {
     )
   }
 
+  # set rmarkdown args to render in tmp dir
+  render_args <- list(output_dir = tempdir())
+
   # run within tutorial wd
   withr::with_dir(tutorial_path, {
     if (!identical(Sys.getenv("SHINY_PORT", ""), "")) {
       # is currently running in a server, do not allow for prerender (rmarkdown::render)
       withr::local_envvar(c(RMARKDOWN_RUN_PRERENDER = "0"))
     }
-    rmarkdown::run(file = NULL, dir = tutorial_path, shiny_args = shiny_args)
+    rmarkdown::run(file = NULL, dir = tutorial_path, shiny_args = shiny_args,
+                   render_args = render_args)
   })
 }
 

--- a/R/run.R
+++ b/R/run.R
@@ -52,7 +52,12 @@ run_tutorial <- function(name = NULL, package = NULL, shiny_args = NULL) {
   }
 
   # set rmarkdown args to render in tmp dir
-  render_args <- list(output_dir = tempdir())
+  temp_output_dir <- tempdir()
+  render_args <- list(
+    output_dir = temp_output_dir,
+    intermediates_dir = temp_output_dir,
+    knit_root_dir = temp_output_dir
+  )
 
   # run within tutorial wd
   withr::with_dir(tutorial_path, {


### PR DESCRIPTION
`learnr` currently renders tutorial documents within the package directory.  This throws an error if `learnr` is installed in a directory that the user does not have write permission in.

This PR renders documents in a temp directory instead.

Closes #347 

PR task list:
- [ x ] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
