### PR TITLE
Question state - include `correct` flag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ learnr (development version)
 * Added an `exercise_submitted` event which is fired before evaluating an exercise. This event can be associated with an `exercise_result` event using the randomly generated `id` included in the data of both events. ([#337](https://github.com/rstudio/learnr/pull/337))
 * Added a `restore` flag on `exercise_submitted` events which is `TRUE` if the exercise is being restored from a previous execution, or `FALSE` if the exercise is being run interactively.
 * Add `label` field to the `exercise_hint` event to identify for which exercise the user requested a hint. ([#377](https://github.com/rstudio/learnr/pull/377))
+* `save_question_submission` now also records the `correct` flag, indicating if the answer was correct or not. This bringing it in line with `question_submission` event.
 
 ## Bug fixes
 

--- a/R/events.R
+++ b/R/events.R
@@ -47,7 +47,8 @@ question_submission_event <- function(session,
   save_question_submission(session = session,
                            label = label,
                            question = question,
-                           answer = answer)
+                           answer = answer,
+                           correct = correct)
 }
 
 reset_question_submission_event <- function(session, label, question) {

--- a/R/storage.R
+++ b/R/storage.R
@@ -1,13 +1,14 @@
 
 
-save_question_submission <- function(session, label, question, answer) {
+save_question_submission <- function(session, label, question, answer, correct) {
   save_object(
     session = session,
     object_id = label,
     tutorial_object("question_submission", list(
       api_version = 1,
       question = question,
-      answer = answer
+      answer = answer,
+      correct = correct
     ))
   )
 }


### PR DESCRIPTION
`question_submission_event` currently records/reports the `label`, `question`, `answer`, and `correct` values for each question submission. However, when the question state is saved the `correct` flag value is not saved -- this is not needed by learnr for restoring state however it is useful if you are trying to collect this state information to record students' answers. I am trying to accomplish something like this in the [rundel/learnrhash](https://github.com/rundel/learnrhash) package - I don't strictly need the `correct` flags but without them it then requires rechecking all of the questions and answers after extracting the state. This would significantly reduce the post processing of the data necessary in order to score students.

In my limited testing this change seems minor and does not affect restoring state of an in progress tutorial.

``````
---
title: "A Minimal Example"
output: learnr::tutorial
runtime: shiny_prerendered
tutorial:
  id: "minimal-example"
  version: 1.0
---

```{r setup, include=FALSE}
library(learnr)

options(tutorial.event_recorder = learnr:::debug_event_recorder)
```

## Question

```{r planets, echo=FALSE}
learnr::question(
  "Which planet do we live on?",
  answer("Mars",   correct = FALSE),
  answer("Earth",  correct = TRUE),
  answer("Saturn", correct = FALSE),
  allow_retry = TRUE
)
```

## Check State

```{r context="server"}
shiny::observeEvent(input$get_state, {
  objs = learnr:::get_all_state_objects(session)
  objs = learnr:::submissions_from_state_objects(objs)
  
  print(str(objs))
})
```

```{r state, ech=FALSE}
shiny::actionButton("get_state", "Get State")
```

``````

---

PR task list:
- [x] Update NEWS
- [ ] Add tests (if possible) - *No tests currently implemented for these `save_*` functions*
- [ ] Update documentation with `devtools::document()` - *Did not change any functions with docs and did not want to include doc changes from unrelated commits.*

CC @mine-cetinkaya-rundel 
