### PR TITLE
Add `smart` documentation to remove check warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     knitr (>= 1.14),
     markdown,
     shiny (>= 1.0),
-    rmarkdown (>= 1.12.0),
+    rmarkdown (>= 2.2.0),
     ellipsis (>= 0.2.0.1),
     checkmate,
     renv (>= 0.8.0),
@@ -41,9 +41,9 @@ Imports:
     promises
 Remotes: rstudio/htmltools
 Encoding: UTF-8
-LazyData: true  
+LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests:
     testthat (>= 2.1.0),
     callr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     knitr (>= 1.14),
     markdown,
     shiny (>= 1.0),
-    rmarkdown (>= 2.2.0),
+    rmarkdown (>= 1.12.0),
     ellipsis (>= 0.2.0.1),
     checkmate,
     renv (>= 0.8.0),

--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -33,7 +33,6 @@ tutorial <- function(fig_width = 6.5,
                      allow_skip = FALSE,
                      dev = "png",
                      df_print = "paged",
-                     smart = TRUE,
                      theme = "rstudio",
                      highlight = "textmate",
                      ace_theme = "textmate",
@@ -127,7 +126,6 @@ tutorial <- function(fig_width = 6.5,
 
   # create base document format using standard html_document
   base_format <- rmarkdown::html_document(
-    smart = smart,
     theme = theme,
     lib_dir = NULL,
     mathjax = mathjax,

--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -20,7 +20,9 @@
 #'        to prevent syntax highlighting.  Note, this value only pertains to standard rmarkdown code, not the Ace editor highlighting.
 #' @param ace_theme Ace theme supplied to the ace code editor for all exercises.
 #'        See \code{learnr:::ACE_THEMES} for a list of possible values.  Defaults to \code{"textmate"}.
-#'
+#' @param smart Produce typographically correct output, converting straight quotes to curly quotes,
+#'        \code{---} to em-dashes, \code{--} to en-dashes, and \code{...} to ellipses.
+#'        Deprecated in \pkg{rmarkdown} v2.2.0.
 #' @param ... Forward parameters to html_document
 #'
 #' @export
@@ -33,6 +35,7 @@ tutorial <- function(fig_width = 6.5,
                      allow_skip = FALSE,
                      dev = "png",
                      df_print = "paged",
+                     smart = TRUE,
                      theme = "rstudio",
                      highlight = "textmate",
                      ace_theme = "textmate",
@@ -126,6 +129,7 @@ tutorial <- function(fig_width = 6.5,
 
   # create base document format using standard html_document
   base_format <- rmarkdown::html_document(
+    smart = smart,
     theme = theme,
     lib_dir = NULL,
     mathjax = mathjax,

--- a/man/initialize_tutorial.Rd
+++ b/man/initialize_tutorial.Rd
@@ -8,6 +8,6 @@ initialize_tutorial()
 }
 \description{
 One time initialization of R Markdown extensions required by the
-\pkg{tutor} package. This function is typically called automatically
+\pkg{learnr} package. This function is typically called automatically
 as a result of using exercises or questions.
 }

--- a/man/tutorial.Rd
+++ b/man/tutorial.Rd
@@ -13,6 +13,7 @@ tutorial(
   allow_skip = FALSE,
   dev = "png",
   df_print = "paged",
+  smart = TRUE,
   theme = "rstudio",
   highlight = "textmate",
   ace_theme = "textmate",
@@ -58,6 +59,10 @@ for formats that produce HTML). In addition to the named methods you can
 also pass an arbitrary function to be used for printing data frames. You
 can disable the \code{df_print} behavior entirely by setting the option
 \code{rmarkdown.df_print} to \code{FALSE}.}
+
+\item{smart}{Produce typographically correct output, converting straight quotes to curly quotes,
+\code{---} to em-dashes, \code{--} to en-dashes, and \code{...} to ellipses.
+Deprecated in \pkg{rmarkdown} v2.2.0.}
 
 \item{theme}{Visual theme ("rstudio", default", "cerulean", "journal", "flatly",
 "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",

--- a/man/tutorial.Rd
+++ b/man/tutorial.Rd
@@ -13,7 +13,6 @@ tutorial(
   allow_skip = FALSE,
   dev = "png",
   df_print = "paged",
-  smart = TRUE,
   theme = "rstudio",
   highlight = "textmate",
   ace_theme = "textmate",
@@ -59,10 +58,6 @@ for formats that produce HTML). In addition to the named methods you can
 also pass an arbitrary function to be used for printing data frames. You
 can disable the \code{df_print} behavior entirely by setting the option
 \code{rmarkdown.df_print} to \code{FALSE}.}
-
-\item{smart}{Produce typographically correct output, converting straight
-quotes to curly quotes, \code{---} to em-dashes, \code{--} to en-dashes, and
-\code{...} to ellipses.}
 
 \item{theme}{Visual theme ("rstudio", default", "cerulean", "journal", "flatly",
 "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",


### PR DESCRIPTION
Code change https://github.com/rstudio/rmarkdown/issues/1774

Example error: https://github.com/rstudio/learnr/pull/390/checks?check_run_id=854831889#step:10:69

PR task list:
- [ ] Update NEWS
- [NA] Add tests (if possible)
- [x] Update documentation with `devtools::document()`
