### PR TITLE
Fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ all of the following:
 5.  Interactive Shiny components.
 
 You can find documentation on using the **learnr** package here:
-<https://rstudio.github.com/learnr/>
+<https://rstudio.github.io/learnr/>
 
 ## FAQ
 


### PR DESCRIPTION
For some reason, running `devtools::build_readme()` introduces hard line breaks in the README.md.