### PR TITLE
Add shinytest support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,9 @@ Imports:
     curl,
     promises,
     digest
-Remotes: rstudio/htmltools
+Remotes:
+    rstudio/htmltools,
+    rstudio/shinytest
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Suggests:
     testthat (>= 2.1.0),
+    shinytest (>= 1.4.0.9002),
     callr,
     rlang,
     httpuv,

--- a/R/learnr.R
+++ b/R/learnr.R
@@ -5,6 +5,7 @@
   # shinytest::registerInputProcessor(), below.
   removeInputHandler("learnr.exercise")
   registerInputHandler("learnr.exercise", function(x, shinysession, name) {
+    snapshotPreprocessInput(name, snapshotPreprocessorLearnrExercise)
     x
   })
 

--- a/R/learnr.R
+++ b/R/learnr.R
@@ -1,3 +1,19 @@
 .onLoad <- function(libname, pkgname) {
   register_default_event_handlers()
+
+  # We need an input handler for learnr.exercise, only so that we can call
+  # shinytest::registerInputProcessor(), below.
+  removeInputHandler("learnr.exercise")
+  registerInputHandler("learnr.exercise", function(x, shinysession, name) {
+    x
+  })
+
+
+  if ("shinytest" %in% loadedNamespaces()) {
+    register_shinytest_inputprocessor()
+  }
+  setHook(
+    packageEvent("shinytest", "onLoad"),
+    function(...) register_shinytest_inputprocessor()
+  )
 }

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -1,7 +1,9 @@
 register_shinytest_inputprocessor <- function() {
-  shinytest::registerInputProcessor("learnr.exercise", function(value) {
-    # Drop all information from `value` except `code`.
-    value <- value["code"]
-    paste(capture.output(dput(value)), collapse = "\n")
-  })
+  if (is_installed("shinytest", "1.4.0.9002")) {
+    shinytest::registerInputProcessor("learnr.exercise", function(value) {
+      # Drop all information from `value` except `code`.
+      value <- value["code"]
+      paste(capture.output(dput(value)), collapse = "\n")
+    })
+  }
 }

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -2,6 +2,6 @@ register_shinytest_inputprocessor <- function() {
   shinytest::registerInputProcesser("learnr.exercise", function(value) {
     # Drop all information from `value` except `code`.
     value <- value["code"]
-    paste(capture.output(dput(value)), collapse = " ")
+    paste(capture.output(dput(value)), collapse = "\n")
   })
 }

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -3,7 +3,7 @@ register_shinytest_inputprocessor <- function() {
     shinytest::registerInputProcessor("learnr.exercise", function(value) {
       # Drop all information from `value` except `code`.
       value <- value["code"]
-      paste(capture.output(dput(value)), collapse = "\n")
+      dput_to_string(value)
     })
   }
 }

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -1,5 +1,5 @@
 register_shinytest_inputprocessor <- function() {
-  shinytest::registerInputProcesser("learnr.exercise", function(value) {
+  shinytest::registerInputProcessor("learnr.exercise", function(value) {
     # Drop all information from `value` except `code`.
     value <- value["code"]
     paste(capture.output(dput(value)), collapse = "\n")

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -1,0 +1,7 @@
+register_shinytest_inputprocessor <- function() {
+  shinytest::registerInputProcesser("learnr.exercise", function(value) {
+    # Drop all information from `value` except `code`.
+    value <- value["code"]
+    paste(capture.output(dput(value)), collapse = " ")
+  })
+}

--- a/R/shinytest.R
+++ b/R/shinytest.R
@@ -1,3 +1,4 @@
+# Input processor, for generating code in shinytest Recorder app
 register_shinytest_inputprocessor <- function() {
   if (is_installed("shinytest", "1.4.0.9002")) {
     shinytest::registerInputProcessor("learnr.exercise", function(value) {
@@ -6,4 +7,10 @@ register_shinytest_inputprocessor <- function() {
       dput_to_string(value)
     })
   }
+}
+
+# Snapshot preprocessor, for massaging input value before taking snapshot.
+snapshotPreprocessorLearnrExercise <- function(value) {
+  value$timestamp <- NULL
+  value
 }

--- a/R/storage.R
+++ b/R/storage.R
@@ -279,6 +279,9 @@ tutorial_storage <- function(session) {
 
   # function to determine "auto" storage
   auto_storage <- function() {
+    if (getOption("shiny.testmode", default = FALSE)) {
+      return(no_storage())
+    }
     location <- read_request(session, "tutorial.http_location")
     if (is_localhost(location))
       local_storage

--- a/R/storage.R
+++ b/R/storage.R
@@ -280,6 +280,8 @@ tutorial_storage <- function(session) {
   # function to determine "auto" storage
   auto_storage <- function() {
     if (getOption("shiny.testmode", default = FALSE)) {
+      # With shinytest, we don't want to restore state; start with a clean slate
+      # each time.
       return(no_storage())
     }
     location <- read_request(session, "tutorial.http_location")

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,3 +98,12 @@ knitr_engine <- function(engine) {
   tolower(engine %||% "r")
 }
 
+is_installed <- function(package, version = NULL) {
+  if (system.file(package = package) == "") {
+    return(FALSE)
+  }
+  if (!is.null(version) && packageVersion(package) < version) {
+    return(FALSE)
+  }
+  TRUE
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,7 +102,7 @@ is_installed <- function(package, version = NULL) {
   if (system.file(package = package) == "") {
     return(FALSE)
   }
-  if (!is.null(version) && packageVersion(package) < version) {
+  if (!is.null(version) && utils::packageVersion(package) < version) {
     return(FALSE)
   }
   TRUE

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1324,6 +1324,15 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
       return value;
     },
 
+    setValue: function(el, value) {
+      var editor = ace.edit($(el).attr('id'));
+      editor.getSession().setValue(value.code);
+    },
+
+    getType: function(el) {
+      return "learnr.exercise";
+    },
+
     subscribe: function(el, callback) {
       var binding = this;
       this.runButtons(el).on('click.exerciseInputBinding', function(ev) {

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1327,6 +1327,8 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
     setValue: function(el, value) {
       var editor = ace.edit($(el).attr('id'));
       editor.getSession().setValue(value.code);
+      // Need to trigger a click for progressive mode.
+      this.runButtons(el).trigger('click');
     },
 
     getType: function(el) {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -358,6 +358,7 @@ $(document).ready(function() {
       return $(scope).find('.topicsList');
     },
     getValue: function(el) {
+      if (currentTopicIndex == -1) return null;
       return topics[currentTopicIndex].id;
     },
     setValue: function(el, value) {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -154,6 +154,8 @@ $(document).ready(function() {
     }
 
     function handleSkipClick(event) {
+      $(this).data('n_clicks', $(this).data('n_clicks') + 1)
+
       var sectionId = this.getAttribute('data-section-id');
       // get the topic & section indexes
       var topicIndex = -1;
@@ -284,7 +286,12 @@ $(document).ready(function() {
         sectionsDOM.each( function( sectionIndex, sectionElement) {
 
           if (topic.progressiveReveal) {
-            var continueButton = $('<button class="btn btn-default skip" data-section-id="' + sectionElement.id + '">Continue</button>');
+            var continueButton = $(
+              '<button class="btn btn-default skip" id="' +
+              'continuebutton-' + sectionElement.id +
+              '" data-section-id="' + sectionElement.id + '">Continue</button>'
+            );
+            continueButton.data('n_clicks', 0);
             continueButton.on('click', handleSkipClick);
             var actions = $('<div class="exerciseActions"></div>');
             actions.append(continueButton);
@@ -377,6 +384,41 @@ $(document).ready(function() {
     }
   });
   Shiny.inputBindings.register(topicMenuInputBinding, 'learnr.topicMenuInputBinding');
+
+  // continueButtonInputBinding
+  // ------------------------------------------------------------------
+  // This keeps tracks of what topic is selected
+  var continueButtonInputBinding = new Shiny.InputBinding();
+  $.extend(continueButtonInputBinding, {
+    find: function(scope) {
+      return $(scope).find('.exerciseActions > button.skip');
+    },
+    getId: function(el) {
+      return 'continuebutton-' + el.getAttribute('data-section-id');
+    },
+    getValue: function(el) {
+      return $(el).data('n_clicks');
+    },
+    setValue: function(el, value) {
+      var old_value = $(el).data('n_clicks');
+      if (value > old_value) {
+        $(el).trigger('click');
+      }
+
+      // Just in case the click event didn't increment n_clicks to be the same
+      // as the `value`, set `n_clicks` to be the same.
+      $(el).data('n_clicks', value);
+    },
+    subscribe: function(el, callback) {
+      $(el).on('click.continueButtonInputBinding', function(event) {
+        callback(false);
+      });
+    },
+    unsubscribe: function(el) {
+      $(el).off('.continueButtonInputBinding');
+    }
+  });
+  Shiny.inputBindings.register(continueButtonInputBinding, 'learnr.continueButtonInputBinding');
 
 
     // transform the DOM here

--- a/learnr.Rproj
+++ b/learnr.Rproj
@@ -16,5 +16,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageInstallArgs: --no-multiarch --with-keep.source
+PackageInstallArgs: --no-multiarch --with-keep.source --no-byte-compile
 PackageRoxygenize: rd,collate,namespace

--- a/man/one_time.Rd
+++ b/man/one_time.Rd
@@ -33,10 +33,6 @@ executed a second time.
 
 A common use for \code{one_time} is to execute an expression when a section is
 viewed for the first time.
-
-Technical note: This is meant to be called within an event handler, instead
-of being implemented as an event handler that removes itself. The reason that
-the latter method isn't used is because it's possible that two users
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Fixes https://github.com/rstudio/shinytest/issues/209

This PR makes it possible to test learnr documents with shinytest. Should be merged after https://github.com/rstudio/shinytest/pull/321


Note: When `progressive: true` is used, there are potential timing issues after the Continue buttons are pressed, and when the Topic changes. This is because the client-side transitions take a bit of time. Users may need to add `Sys.sleep()` after setting these values for tests to work properly and consistently.

For example, here's a test script for a learnr tutorials with `progressive: true`. It required `Sys.sleep()` calls to work correctly. 

```
app <- ShinyDriver$new("../../Untitled.Rmd", seed = 50943)
app$snapshotInit("mytest")

app$setInputs(`tutorial-exercise-two-plus-two-code-editor` = list(code = "\n2+2\n"))
app$setInputs(`continuebutton-section-exercise` = 1)
Sys.sleep(1)  # Sleep after Continue button is clicked
app$snapshot()
app$setInputs(`tutorial-exercise-add-function-code-editor` = list(code = "add <- function() {\n  2\n}"))
app$snapshot()
app$setInputs(`continuebutton-section-exercise-with-code` = 1)
app$setInputs(`tutorial-topic` = "section-topic-2")
Sys.sleep(0.5) Sys.sleep(1)  # Sleep after Topic change
app$snapshot()
app$setInputs(`tutorial-exercise-print-limit-code-editor` = list(code = "head(mtcars, 5)\n\n"))
app$snapshot()
app$setInputs(`continuebutton-section-exercise-with-hint` = 1)
app$setInputs(`quiz-1-answer` = "utils")
app$setInputs(`quiz-1-action_button` = "click")
app$snapshot()
app$setInputs(`quiz-2-answer` = "lattice")
app$setInputs(`quiz-2-answer` = c("lattice", "stats"))
app$setInputs(`quiz-2-action_button` = "click")
app$snapshot()
```

For non-progressive tutorials, `Sys.sleep()` shouldn't be necessary. Also, there are no Continue buttons in non-progessive mode.


TODO:

- [x] Figure out how to reset state before testing - use `no_storage()` when `getOption("shiny.testmode")` is TRUE.
- [x] Add input binding for Topic
- [x] Don't record ``input$`tutorial-visible-sections` ``. Note: This is automatically not recorded because there isn't an input binding for the visible sections.
- [x] Make sure learnr is loaded in R session that calls `recordTest()`
