### PR TITLE
Save tutorial output to temp folder when tutorial folder does not have write permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ learnr (development version)
 * Renamed the `exercise_submission` event to `exercise_result` and added the following fields:
   1. `id` - a randombly generated identifier that can be used to align with the associated `exercise_result` event.
   2. `time_elapsed` - the time required to run the exercise (in seconds)
-  3. `timeout_exceeded` - indicates whether the exercise was interrupted due to an exceeded timeout. May be `NA` for some platforms/evaluators if that information is not known or reported. ([#337](https://github.com/rstudio/learnr/pull/337))  
+  3. `timeout_exceeded` - indicates whether the exercise was interrupted due to an exceeded timeout. May be `NA` for some platforms/evaluators if that information is not known or reported. ([#337](https://github.com/rstudio/learnr/pull/337))
 * If a `-code-check` chunk returns feedback for an exercise submission, the result of the exercise is no longer displayed for a correct answer (only the feedback is displayed). If both the result and feedback should be displayed, all checking should be performed in a `-check` chunk (i.e., don't provide a `-code-check` chunk). ([#403](https://github.com/rstudio/learnr/pull/403))
 
 ## New features
@@ -33,6 +33,7 @@ learnr (development version)
 * Properly enforce time limits and measure exercise execution times that exceed 60 seconds ([#366](https://github.com/rstudio/learnr/pull/366), [#368](https://github.com/rstudio/learnr/pull/368))
 * Fixed unexpected behavior for `question_is_correct.learnr_text()` where `trim = FALSE`. Comparisons will now happen with the original input value, not the `HTML()` formatted answer value. ([#376](https://github.com/rstudio/learnr/pull/376))
 * Fixed exercise progress spinner being prematurely cleared. ([#384](https://github.com/rstudio/learnr/pull/384))
+* Render tutorials in a temp directory if the R user does not have write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
 
 learnr 0.10.1
 ===========

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ learnr (development version)
 * Properly enforce time limits and measure exercise execution times that exceed 60 seconds ([#366](https://github.com/rstudio/learnr/pull/366), [#368](https://github.com/rstudio/learnr/pull/368))
 * Fixed unexpected behavior for `question_is_correct.learnr_text()` where `trim = FALSE`. Comparisons will now happen with the original input value, not the `HTML()` formatted answer value. ([#376](https://github.com/rstudio/learnr/pull/376))
 * Fixed exercise progress spinner being prematurely cleared. ([#384](https://github.com/rstudio/learnr/pull/384))
-* Render tutorials in a temp directory if the R user does not have write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
+* Updated `run_tutorial()` to render tutorials in a temp directory if the R user does not have write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
 
 learnr 0.10.1
 ===========

--- a/R/run.R
+++ b/R/run.R
@@ -69,7 +69,7 @@ run_tutorial <- function(name = NULL, package = NULL, shiny_args = NULL) {
       })
     }, error = function(e) {
       # Could not write in the tutorial folder
-      message("Rendering tutorial in a temp folder as `learnr` does not have write permissions in the tutorial folder: ", tutorial_path)
+      message("Rendering tutorial in a temp folder since `learnr` does not have write permissions in the tutorial folder: ", tutorial_path)
 
       # Set rmarkdown args to render in tmp dir
       # This will cause the tutorial to be re-rendered in each R session

--- a/R/run.R
+++ b/R/run.R
@@ -63,12 +63,13 @@ run_tutorial <- function(name = NULL, package = NULL, shiny_args = NULL) {
           }
         }, add = TRUE)
         # write to the test file
-        cat("test", file = tmp_save_file)
+        suppressWarnings(cat("test", file = tmp_save_file))
         # if no errors have occurred, return an empty list of render_args
         list()
       })
     }, error = function(e) {
       # Could not write in the tutorial folder
+      message("Rendering tutorial in a temp folder as `learnr` does not have write permissions in the tutorial folder: ", tutorial_path)
 
       # Set rmarkdown args to render in tmp dir
       # This will cause the tutorial to be re-rendered in each R session

--- a/R/run.R
+++ b/R/run.R
@@ -51,13 +51,45 @@ run_tutorial <- function(name = NULL, package = NULL, shiny_args = NULL) {
     )
   }
 
+  render_args <-
+    tryCatch({
+      local({
+        # try to save a file to check for write permissions
+        tmp_save_file <- file.path(tutorial_path, "__leanr_test_file")
+        # make sure it's deleted
+        on.exit({
+          if (file.exists(tmp_save_file)) {
+            unlink(tmp_save_file)
+          }
+        }, add = TRUE)
+        # write to the test file
+        cat("test", file = tmp_save_file)
+        # if no errors have occurred, return an empty list of render_args
+        list()
+      })
+    }, error = function(e) {
+      # Could not write in the tutorial folder
+
+      # Set rmarkdown args to render in tmp dir
+      # This will cause the tutorial to be re-rendered in each R session
+      temp_output_dir <- file.path(tempdir(), "learnr", package, name)
+      if (!dir.exists(temp_output_dir)) {
+        dir.create(temp_output_dir, recursive = TRUE)
+      }
+      list(
+        output_dir = temp_output_dir,
+        intermediates_dir = temp_output_dir,
+        knit_root_dir = temp_output_dir
+      )
+    })
+
   # run within tutorial wd
   withr::with_dir(tutorial_path, {
     if (!identical(Sys.getenv("SHINY_PORT", ""), "")) {
       # is currently running in a server, do not allow for prerender (rmarkdown::render)
       withr::local_envvar(c(RMARKDOWN_RUN_PRERENDER = "0"))
     }
-    rmarkdown::run(file = NULL, dir = tutorial_path, shiny_args = shiny_args)
+    rmarkdown::run(file = NULL, dir = tutorial_path, shiny_args = shiny_args, render_args = render_args)
   })
 }
 


### PR DESCRIPTION
Fixes #347

Heavily inspired from #387 , but did not receive contact from OP.

PR task list:
- [x] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`