### PR TITLE
Disable completion of R code inside quotes, closes #401

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,8 @@ learnr (development version)
 * Fixed unexpected behavior for `question_is_correct.learnr_text()` where `trim = FALSE`. Comparisons will now happen with the original input value, not the `HTML()` formatted answer value. ([#376](https://github.com/rstudio/learnr/pull/376))
 * Fixed exercise progress spinner being prematurely cleared. ([#384](https://github.com/rstudio/learnr/pull/384))
 * Updated `run_tutorial()` to render tutorials in a temp directory if the R user does not have write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
-* An informative error is now thrown when an exercise chunk's body contains nothing, which lets the tutorial author know that something (e.g., empty line(s)) must be present in the chunk body for it to be rendered as an exercise. ([#410](https://github.com/rstudio/learnr/issues/410)) ([#172](https://github.com/rstudio/learnr/issues/172)) 
+* An informative error is now thrown when an exercise chunk's body contains nothing, which lets the tutorial author know that something (e.g., empty line(s)) must be present in the chunk body for it to be rendered as an exercise. ([#410](https://github.com/rstudio/learnr/issues/410)) ([#172](https://github.com/rstudio/learnr/issues/172))
+* When `exercise.completion=TRUE`, completion is no longer performed inside of quotes. This (intentionally) prevents the student from being able to list files on the R server ([#401](https://github.com/rstudio/learnr/issues/401)).
 
 learnr 0.10.1
 ===========

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -187,7 +187,7 @@ register_http_handlers <- function(session, metadata) {
     settings <- utils::rc.settings()
     utils::rc.settings(ops = TRUE, ns = TRUE, args = TRUE, func = FALSE,
                        ipck = TRUE, S3 = TRUE, data = TRUE, help = TRUE,
-                       argdb = TRUE, fuzzy = FALSE, files = TRUE, quotes = TRUE)
+                       argdb = TRUE, fuzzy = FALSE, files = TRUE, quotes = FALSE)
     on.exit(do.call(utils::rc.settings, as.list(settings)), add = TRUE)
 
     # temporarily attach global setup to search path

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -187,7 +187,7 @@ register_http_handlers <- function(session, metadata) {
     settings <- utils::rc.settings()
     utils::rc.settings(ops = TRUE, ns = TRUE, args = TRUE, func = FALSE,
                        ipck = TRUE, S3 = TRUE, data = TRUE, help = TRUE,
-                       argdb = TRUE, fuzzy = FALSE, files = TRUE, quotes = FALSE)
+                       argdb = TRUE, fuzzy = FALSE, files = FALSE, quotes = FALSE)
     on.exit(do.call(utils::rc.settings, as.list(settings)), add = TRUE)
 
     # temporarily attach global setup to search path

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -184,6 +184,9 @@ register_http_handlers <- function(session, metadata) {
                       function.suffix = "(")
     on.exit(do.call(utils::rc.options, as.list(options)), add = TRUE)
 
+    # If and when exercises gain access to files, then we should evaluate this
+    # code in the exercise dir with `quotes = TRUE` (and sanitize to keep
+    # filename lookup local to exercise dir)
     settings <- utils::rc.settings()
     utils::rc.settings(ops = TRUE, ns = TRUE, args = TRUE, func = FALSE,
                        ipck = TRUE, S3 = TRUE, data = TRUE, help = TRUE,


### PR DESCRIPTION
See #401 for motivation.

This disables completion of R code inside quotes (when `exercise.completion = TRUE`), by setting `quotes = FALSE` in `rc.settings()`...the docs for `quotes` says:

> Enables completion in R code when inside quotes. This normally leads to filename completion, but can be otherwise depending on context (for example, when the open quote is preceded by ?), help completion is invoked. Setting this to FALSE relegates completion to the underlying completion front-end, which may do its own processing (for example, readline on Unix-alikes will do filename completion).

Thus, this might be a slightly over-agressive way to prevent filenames from being displayed. Note that there is also a `files` argument that we could set to `FALSE`, but for some reason that arg is deprecated (maybe it's effectively the same as `quotes`?)