### PR TITLE
Validate the ability to create an idb store

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: learnr
 Type: Package
 Title: Interactive Tutorials for R
-Version: 0.10.1.9005
+Version: 0.10.1.9006
 Authors@R: c(
   person("Barret", "Schloerke", role = c("aut", "cre"), email = "barret@rstudio.com",
         comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ learnr (development version)
 * Updated `run_tutorial()` to render tutorials in a temp directory if the R user does not have write permissions. ([#347](https://github.com/rstudio/learnr/issues/347))
 * An informative error is now thrown when an exercise chunk's body contains nothing, which lets the tutorial author know that something (e.g., empty line(s)) must be present in the chunk body for it to be rendered as an exercise. ([#410](https://github.com/rstudio/learnr/issues/410)) ([#172](https://github.com/rstudio/learnr/issues/172))
 * When `exercise.completion=TRUE`, completion is no longer performed inside of quotes. This (intentionally) prevents the student from being able to list files on the R server ([#401](https://github.com/rstudio/learnr/issues/401)).
+* Fail gracefully when unable to open an indexedDB store (e.g. in cross-origin iframes in Safari). ([#417](https://github.com/rstudio/learnr/issues/417)).
 
 learnr 0.10.1
 ===========

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1455,6 +1455,29 @@ Tutorial.prototype.$initializeStorage = function(identifiers, success) {
     })
   }
 
+  // Validate that we can actually open a store. Some browsers (e.g. Safari)
+  // pass the previous tests but will deny access to the idb store in certain
+  // context (such as a cross-origin iframe). This check ensures that we fail
+  // fast in such scenarios.
+  var storeCreated;
+  try{
+    testStore = new window.idbKeyval.Store(
+      dbName,
+      storeName
+    );
+    closeStore(testStore);
+    storeCreated = true;
+  } catch (error){
+    // Unable to open store.
+    storeCreated = false;
+  }
+  if (storeCreated === false) {
+    // can not do db stuff.
+    // return early and do not create hooks
+    success({});
+    return;
+  }
+
   // tl/dr; Do not keep indexedDB connections around
 
   // All interactions must:


### PR DESCRIPTION
The prior checks (line 1437 currently) test whether or not the browser supports the necessary features, but it doesn't actually exercise whether or not we're allowed to create a store here. Some browsers (such as Safari) have additional restrictions in e.g. cross-origin iframes that preclude us from successfully opening an idb store. This check ensures that we can actually create a store, or fails fast if not.

The error caused issues whether or not idb was ultimately used as the store for learnr state.

Without this, Safari is throwing the following error:

```
[Error] SecurityError: IDBFactory.open() called in an invalid security context
	open (idb-keyval-iife-compat.min.js:7:843)
	e (idb-keyval-iife-compat.min.js:7:843)
	(anonymous function) (tutorial.js:1518)
	(anonymous function) (tutorial.js:1705)
	c (jquery.min.js:2:28300)
	fireWith (jquery.min.js:2:29041)
	l (jquery.min.js:2:79812)
	(anonymous function) (jquery.min.js:2:82256)
[Error] SyntaxError: JSON Parse error: Unexpected identifier "object"
	r (chunk-vendors.a5db6293.js:83:31379)
```

## Testing/Validation

This one's a doozy..

This PR better handles scenario where a feature we use to track the state of the user's learnr lesson called "IndexedDB" (IDB) is not supported. Previously, if a browser didn't support IDB we would silently fail and just throw away the user's learnr state at the end of the lesson. That's acceptable if the browser isn't able to store anything. 

Unfortunately there's a bug in which learnr _thought_ that IDB was supported in certain conditions but then when the browser goes to use it we only then see a failure. learnr didn't handle that gracefully. This PR fixes that.

There's a 2x2 matrix of scenarios that we care about:

|    | IDB available | IDB not available |
|--|----------------|------------------|
| custom storage | ✅ | Should work |
| IDB storage | ✅ | Should work, but no results saved |

Prior to this PR, if IDB was not available you'd just get an error in the console and various features didn't work at all (e.g. multiple choice questions didn't render). As of this PR, the top right box should now work just fine. And the lower right box should work with the noted caveat that results aren't going to be saved.

(Note that the test app I setup for custom storage just uses a single file to store everyone's state. So if you had multiple users active on the app at the same time, they'd just be overwriting each other's state which would be confusing.)

The easiest way to simulate an environment where IDB is not available currently is to use Safari where the learnr doc is hosted inside a cross-origin iframe. 

I went ahead and deployed a few of these for testing:

|  | learnr v 9005 (master) | learnr v 9006 (this PR) | 
|--|----------------|----------------|
| Custom Storage | [custom-9005](https://trestletech.github.io/pr417-demo/custom-9005.html) | [custom-9006](https://trestletech.github.io/pr417-demo/custom-9006.html) |
| IDB Storage | [idb-9005](https://trestletech.github.io/pr417-demo/idb-9005.html) | [idb-9006](https://trestletech.github.io/pr417-demo/idb-9006.html) |

In a browser like Firefox or Chrome, IDB is always available even with cross-origin iframes. But if you use Safari on those links, you'll have an environment where IDB fails. 

- If you visit the 9005 links in Safari, you should see them both fail (error in the console, state is not preserved across refreshes, some widgets don't render properly). 
 - When you visit the 9006 links (this PR), you should see no JS console error and everything render properly. With `custom-9006`, you should see state preserved across refreshes (and even in between browsers). With `idb-9006`, all of the features should work except when you refresh the page, you'll start over at a blank app. Because we have no way to store learnr state so we silently gracefully fail.

All that to say:

 - [ ] Observe the failures on `custom-9005` or `idb-9005` on Safari and a JS error. The multiple choice question doesn't load properly.  (Click the "Sample Learnr Widgets" section)
 - [ ] Ensure Safari on `custom-9006` works and preserves state across refreshes
 - [ ] Ensure Safari on `idb-9006` works other than starting over every time you refresh (no state storage)
 - [ ] Ensure Firefox/Chrome/Edge (?) work on `custom-9006` and on `idb-9006` -- including preserving state across refreshes on both.