### PR TITLE
Add an exercise test case with error as solution

### DIFF
--- a/inst/examples/external/evaluator-tests.Rmd
+++ b/inst/examples/external/evaluator-tests.Rmd
@@ -23,7 +23,6 @@ x <- "123"
 library(gradethis)
 ```
 
-
 ## Basics
 
 ```{r basics1, exercise=TRUE}
@@ -195,6 +194,28 @@ grade_result(
 ```
 
 If you enter `3`, you should see an error: `Custom message for value 3.`. If you enter `4`, you should see a success message with praise.
+
+### Check that accepts an exception
+
+Throw an error message of `"boom"`
+
+```{r grade_error, exercise = TRUE}
+stop("boom")
+```
+
+```{r grade_error-solution}
+stop("boom")
+```
+
+```{r grade_error-code-check}
+grade_code("Nice error!")
+```
+
+If you run `stop("boom")`, you should see a red box with `boom`.
+
+If you submit `stop("boom")`, you should see a green box that has `Nice error!`.
+
+For incorrect submission, you should see a red box with a random encouragement message.
 
 ## Isolation & Malicious Code
 


### PR DESCRIPTION
## Description

This adds another test case for [evaluator-tests.Rmd](https://github.com/rstudio/learnr/blob/master/inst/examples/external/evaluator-tests.Rmd) taken from [grading-demo.Rmd](https://github.com/rstudio-education/gradethis/blob/6baf2d9ca584a526761ae76b0510dc274bde0561/inst/tutorials/grading-demo/grading-demo.Rmd#L261-L273) to make sure exercise checking with a `stop()` as solution works on external evaluator.
