### PR TITLE
Remove exercise.error.checker in favor of exercise.error.check.code and -error-check chunks

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -65,6 +65,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
     # - solution
     # - engine
     exercise <- append(exercise, get_exercise_cache(exercise$label))
+    # If there is no locally defined error check code, look for globally defined error check option
     exercise$error_check <- exercise$error_check %||% exercise$options$exercise.error.check.code
     if (!isTRUE(exercise$should_check)) {
       exercise$check <- NULL

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -61,13 +61,15 @@ setup_exercise_handler <- function(exercise_rx, session) {
     exercise$global_setup <- get_global_setup()
     # retrieve exercise cache information:
     # - chunks (setup + exercise) for the exercise to be processed in `evaluate_exercise`
-    # - checker code (check, code-check)
+    # - checker code (check, code-check, error-check)
     # - solution
     # - engine
     exercise <- append(exercise, get_exercise_cache(exercise$label))
+    exercise$error_check <- exercise$error_check %||% exercise$options$exercise.error.check.code
     if (!isTRUE(exercise$should_check)) {
       exercise$check <- NULL
       exercise$code_check <- NULL
+      exercise$error_check <- NULL
     }
     # variable has now served its purpose so remove it
     exercise$should_check <- NULL
@@ -391,12 +393,11 @@ render_exercise <- function(exercise, envir, envir_prep) {
     if (grepl(pattern, msg, fixed = TRUE)) {
       return(exercise_result_timeout())
     }
-    error_check_code <- exercise$error_check %||% exercise$options$exercise.error.check.code
-    if (length(error_check_code)) {
+    if (length(exercise$error_check)) {
       # Run the condition through an error checker (the exercise could be to throw an error!)
       checker_feedback <- try_checker(
         exercise, "exercise.checker",
-        check_code = error_check_code,
+        check_code = exercise$error_check,
         envir_result = envir,
         evaluate_result = evaluate_result,
         envir_prep = envir_prep,

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -391,20 +391,22 @@ render_exercise <- function(exercise, envir, envir_prep) {
     if (grepl(pattern, msg, fixed = TRUE)) {
       return(exercise_result_timeout())
     }
-    # Run the condition through an error checker (the exercise could be to throw an error!)
-    checker_feedback <- try_checker(
-      exercise, "exercise.error.checker",
-      check_code = exercise$check,
-      envir_result = envir,
-      evaluate_result = evaluate_result,
-      envir_prep = envir_prep,
-      last_value = e
-    )
-    if (is_exercise_result(checker_feedback)) {
-      checker_feedback
-    } else {
-      exercise_result_error(msg)
+    error_check_code <- exercise$error_check %||% exercise$options$exercise.error.check.code
+    if (length(error_check_code)) {
+      # Run the condition through an error checker (the exercise could be to throw an error!)
+      checker_feedback <- try_checker(
+        exercise, "exercise.checker",
+        check_code = error_check_code,
+        envir_result = envir,
+        evaluate_result = evaluate_result,
+        envir_prep = envir_prep,
+        last_value = e
+      )
+      if (is_exercise_result(checker_feedback)) {
+        return(checker_feedback)
+      }
     }
+    exercise_result_error(msg)
   })
 
   if (is_exercise_result(output_file)) {

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -27,6 +27,7 @@ install_knitr_hooks <- function() {
                                                           "hint",
                                                           "hint-\\d+",
                                                           "solution",
+                                                          "error-check",
                                                           "code-check",
                                                           "check")) {
     support_regex <- paste0("-(", paste(type, collapse = "|"), ")$")
@@ -184,7 +185,7 @@ install_knitr_hooks <- function() {
       options$highlight <- FALSE
     }
 
-    if (is_exercise_support_chunk(options, type = c("code-check", "check"))) {
+    if (is_exercise_support_chunk(options, type = c("code-check", "error-check", "check"))) {
       options$include <- FALSE
     }
 
@@ -275,6 +276,7 @@ install_knitr_hooks <- function() {
         all_chunks <- get_all_chunks(options)
 
         code_check_chunk <- get_knitr_chunk(paste0(options$label, "-code-check"))
+        error_check_chunk <- get_knitr_chunk(paste0(options$label, "-error-check"))
         check_chunk <- get_knitr_chunk(paste0(options$label, "-check"))
         solution <- get_knitr_chunk(paste0(options$label, "-solution"))
 
@@ -294,6 +296,7 @@ install_knitr_hooks <- function() {
         exercise_cache <- list(setup = all_setup_code,
                                chunks = all_chunks,
                                code_check = code_check_chunk,
+                               error_check = error_check_chunk,
                                check = check_chunk,
                                solution  = solution,
                                options = options,

--- a/R/options.R
+++ b/R/options.R
@@ -13,8 +13,8 @@
 #'   number of lines in the code chunk).
 #' @param exercise.checker Function used to check exercise answers
 #'   (e.g., `gradethis::grade_learnr()`).
-#' @param exercise.error.checker Function used to check exercise answers
-#'   (e.g., `gradethis::grade_learnr_error()`).
+#' @param exercise.error.check.code A string containing R code to use for checking
+#'   code when an exercise evaluation error occurs (e.g., `"gradethis::grade_code()"`).
 #' @param exercise.completion Use code completion in exercise editors.
 #' @param exercise.diagnostics Show diagnostics in exercise editors.
 #' @param exercise.startover Show "Start Over" button on exercise.
@@ -25,7 +25,7 @@ tutorial_options <- function(exercise.cap = "Code",
                              exercise.timelimit = 30,
                              exercise.lines = NULL,
                              exercise.checker = NULL,
-                             exercise.error.checker = NULL,
+                             exercise.error.check.code = NULL,
                              exercise.completion = TRUE,
                              exercise.diagnostics = TRUE,
                              exercise.startover = TRUE)
@@ -39,7 +39,7 @@ tutorial_options <- function(exercise.cap = "Code",
   eval(parse(text = sprintf(set_option_code, "exercise.timelimit")))
   eval(parse(text = sprintf(set_option_code, "exercise.lines")))
   eval(parse(text = sprintf(set_option_code, "exercise.checker")))
-  eval(parse(text = sprintf(set_option_code, "exercise.error.checker")))
+  eval(parse(text = sprintf(set_option_code, "exercise.error.check.code")))
   eval(parse(text = sprintf(set_option_code, "exercise.completion")))
   eval(parse(text = sprintf(set_option_code, "exercise.diagnostics")))
   eval(parse(text = sprintf(set_option_code, "exercise.startover")))

--- a/man/tutorial_options.Rd
+++ b/man/tutorial_options.Rd
@@ -10,7 +10,7 @@ tutorial_options(
   exercise.timelimit = 30,
   exercise.lines = NULL,
   exercise.checker = NULL,
-  exercise.error.checker = NULL,
+  exercise.error.check.code = NULL,
   exercise.completion = TRUE,
   exercise.diagnostics = TRUE,
   exercise.startover = TRUE
@@ -31,8 +31,8 @@ number of lines in the code chunk).}
 \item{exercise.checker}{Function used to check exercise answers
 (e.g., \code{gradethis::grade_learnr()}).}
 
-\item{exercise.error.checker}{Function used to check exercise answers
-(e.g., \code{gradethis::grade_learnr_error()}).}
+\item{exercise.error.check.code}{A string containing R code to use for checking
+code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_code()"}).}
 
 \item{exercise.completion}{Use code completion in exercise editors.}
 


### PR DESCRIPTION
Fixes #356 
Fixes #425 
Fixes https://github.com/rstudio-education/gradethis/issues/140
Related https://github.com/rstudio-education/gradethis/pull/143

After feedback from @garrettgman, and discussion with @schloerke, it's becoming apparent the `exercise.error.checker` probably isn't the right approach to exercise (evaluation) error checking.

This PR replaces `exercise.error.checker` with a slightly different option, `exercise.error.check.code`, which defines what checking code to run when an exercise error occurs. This option, in some sense, provides a global default value, which can be overridden for a particular exercise with a `-error-check` chunk. Overall this seems like a much cleaner solution than `exercise.error.checker`  since it decouples error checking code from `-code-check` (pre-evaluation) and `-check` (post evaluation)

````
```{r setup, include=FALSE}
library(learnr)
library(gradethis)

tutorial_options(
  exercise.checker = gradethis::grade_learnr,
  exercise.error.check.code = "gradethis::grade_code()"
)
knitr::opts_chunk$set(echo = FALSE)
```

* Enter `mtcars`

```{r mtcars, exercise = TRUE}

```

```{r mtcars-solution}
mtcars
```

```{r mtcars-error-check}
grade_code(incorrect = "This code produces an error (press 'Run Code' to see it).", glue_incorrect = "{ .message } { .incorrect }")
```

```{r mtcars-check}
grade_result(
  fail_if(~identical(.result, cars), "This is the cars (not mtcars) dataset."),
  pass_if(~identical(.result, mtcars))
)
```
````