### PR TITLE
Use the setup_options$engine, not options$engine.

### DIFF
--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -104,7 +104,7 @@ install_knitr_hooks <- function() {
           label = setup_label,
           code = paste0(setup_chunk, collapse = "\n"),
           opts = lapply(setup_options, dput_to_string),
-          engine = knitr_engine(options$engine)
+          engine = knitr_engine(setup_options$engine)
         )
       )
     }


### PR DESCRIPTION
Otherwise the parent was using the child's engine

PR task list:
- [NA] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`

Before this PR, this doc did not work as chunk `even_more_setup ` was having an engine of `python`. After this PR, this document works as expected.


Example Doc:

````
---
title: "Chained setup chunks"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include = FALSE}
library(learnr)
library(reticulate)
```

```{r even_more_setup}
d <- 3
```

# learnr + reticulate demo

<!-- Create Python variable `a` which reads `d` from R: -->

```{python setupA, exercise.setup = "even_more_setup"}
a = r.d + 2 # 5
```

<!-- Read `a` from Python, and create `b`: -->

```{r setupB, exercise.setup = "setupA"}
b <- py$a + d # 8
```

R exercise that uses `b` (via R and python setup chunks):

```{r ex1, exercise = TRUE, exercise.setup = "setupB"}
b + 1 # 9
```

Python exercise using `b` (via R and python setup chunks):
```{python ex2, exercise = TRUE, exercise.setup = "setupB"}
r.b + 1 # 9
```
````

