### PR TITLE
Disable anchor sections for learnr tutorials

### DIFF
--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -137,6 +137,7 @@ tutorial <- function(fig_width = 6.5,
     template = "default",
     extra_dependencies = extra_dependencies,
     bootstrap_compatible = TRUE,
+    anchor_sections = FALSE,
     ...
   )
 

--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -47,6 +47,10 @@ tutorial <- function(fig_width = 6.5,
                      pandoc_args = NULL,
                      ...) {
 
+  if ("anchor_sections" %in% names(list(...))) {
+    stop("learnr tutorials do not support the `anchor_sections` option.")
+  }
+
   # base pandoc options
   args <- c()
 

--- a/tests/testthat/test-tutorial-format.R
+++ b/tests/testthat/test-tutorial-format.R
@@ -1,0 +1,8 @@
+test_that("tutorial() returns an rmarkdown format", {
+  expect_true(inherits(tutorial(), "rmarkdown_output_format"))
+})
+
+test_that("tutorial() does not support anchor_sections", {
+  expect_error(tutorial(anchor_sections = TRUE), "do not support")
+  expect_error(tutorial(anchor_sections = FALSE), "do not support")
+})


### PR DESCRIPTION
Fixes #446

Permanently disables section anchors by hard coding `anchor_sections = FALSE`.

@schloerke When a user tries to set `anchor_sections: true` the following error is thrown

```
Error in rmarkdown::html_document(smart = smart, theme = theme, lib_dir = NULL,  : 
  formal argument "anchor_sections" matched by multiple actual arguments
```

Would you like me to check the `...` and throw an informative error message if `anchor_sections` is set?