### PR TITLE
Enable "Submit Answer" button if any check chunks are present

### DIFF
--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -357,9 +357,11 @@ install_knitr_hooks <- function() {
               paste0(cap_engine_val, " code")
             }
           }
+
+        check_chunks <- exercise_cache[grepl("check$", names(exercise_cache))]
         ui_options <- list(
           engine = options$engine,
-          has_checker = (!is.null(check_chunk) || !is.null(code_check_chunk)),
+          has_checker = !all(vapply(check_chunks, is.null, logical(1))),
           caption = caption
         )
         extra_html <- c('<script type="application/json" data-ui-opts="1">',


### PR DESCRIPTION
Fixes an issue when an error is expected but having an `-error-check` chunk alone doesn't lead to a Submit Answer button. Any chunk ending in "check" will now trigger the answer-checking button.

Reprex tutorial

````markdown
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)
library(gradethis)
gradethis_setup()
```

## Error

Should have a submit answer button.

```{r ex, exercise = TRUE}
runif(max = 10)
```

```{r ex-solution}
runif(max = 10)
```

```{r ex-error-check}
grade_this(
  pass("Good job!\n\n```\n{.last_value$message}\n```")
)
```
````

Before

![image](https://user-images.githubusercontent.com/5420529/103235027-132d3900-490f-11eb-9c09-3bbeccc5e68e.png)

After

![image](https://user-images.githubusercontent.com/5420529/103235064-2b04bd00-490f-11eb-9922-e553c0e490cf.png)
