### PR TITLE
question_text() uses textAreaInput() if rows or cols are provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ learnr (development version)
 * `exercise.cap` now accepts HTML input. If no `exercise.cap` is provided, an icon of the exercise engine will be displayed. If no icon is known, the `exercise.cap` will default to the combination of the exercise engine and `" code"`. ([#397](https://github.com/rstudio/learnr/pull/397), [#429](https://github.com/rstudio/learnr/pull/429))
 * `engine` is now passed to the `exercise.checker` to help distinguish what language is being checked in the exercise. ([#397](https://github.com/rstudio/learnr/pull/397))
 * Hitting the `TAB` key in an exercise has always opened the auto-completion drop down. Now, hitting the `TAB` key will also complete the currently selected code completion. ([#428](https://github.com/rstudio/learnr/pull/428))
+* `question_text()` gains `rows` and `cols` parameters. If either is provided, a multi-line `textAreaInput()` is used for the text input. ([#460](https://github.com/rstudio/learnr/pull/460), [#455](https://github.com/rstudio/learnr/issues/455))
 
 ## Bug fixes
 

--- a/R/question_text.R
+++ b/R/question_text.R
@@ -5,7 +5,11 @@
 #'
 #' @inheritParams question
 #' @inheritParams shiny::textInput
-#' @inheritParams shiny::textAreaInput
+#' @param rows,cols Defines the size of the text input area in terms of the
+#'   number of rows or character columns visible to the user. If either `rows`
+#'   or `cols` are provided, the quiz input will use [shiny::textAreaInput()]
+#'   for the text input, otherwise the default input element is a single-line
+#'   [shiny::textInput()].
 #' @param ... answers and extra parameters passed onto \code{\link{question}}.
 #' @param trim Logical to determine if whitespace before and after the answer should be removed.  Defaults to \code{TRUE}.
 #' @seealso \code{\link{question_radio}}, \code{\link{question_checkbox}}
@@ -64,7 +68,7 @@ question_text <- function(
 
 question_ui_initialize.learnr_text <- function(question, value, ...) {
   # Use textInput() unless one of rows or cols are provided
-  textInputFn <- 
+  textInputFn <-
     if (is.null(question$options$rows) && is.null(question$options$cols)) {
       textInput
     } else {

--- a/R/question_text.R
+++ b/R/question_text.R
@@ -64,13 +64,14 @@ question_text <- function(
 
 question_ui_initialize.learnr_text <- function(question, value, ...) {
   # Use textInput() unless one of rows or cols are provided
-  textInputFn <- if (is.null(question$options$rows) && is.null(question$options$cols)) {
-    textInput
-  } else {
-    function(...) {
-      textAreaInput(..., cols = question$options$cols, rows = question$options$rows)
+  textInputFn <- 
+    if (is.null(question$options$rows) && is.null(question$options$cols)) {
+      textInput
+    } else {
+      function(...) {
+        textAreaInput(..., cols = question$options$cols, rows = question$options$rows)
+      }
     }
-  }
 
   textInputFn(
     question$ids$answer,

--- a/R/question_text.R
+++ b/R/question_text.R
@@ -5,6 +5,7 @@
 #'
 #' @inheritParams question
 #' @inheritParams shiny::textInput
+#' @inheritParams shiny::textAreaInput
 #' @param ... answers and extra parameters passed onto \code{\link{question}}.
 #' @param trim Logical to determine if whitespace before and after the answer should be removed.  Defaults to \code{TRUE}.
 #' @seealso \code{\link{question_radio}}, \code{\link{question_checkbox}}
@@ -31,6 +32,8 @@ question_text <- function(
   random_answer_order = FALSE,
   placeholder = "Enter answer here...",
   trim = TRUE,
+  rows = NULL,
+  cols = NULL,
   options = list()
 ) {
   checkmate::assert_character(placeholder, len = 1, null.ok = TRUE, any.missing = FALSE)
@@ -48,7 +51,9 @@ question_text <- function(
       options,
       list(
         placeholder = placeholder,
-        trim = trim
+        trim = trim,
+        rows = rows,
+        cols = cols
       )
     )
   )
@@ -58,7 +63,16 @@ question_text <- function(
 
 
 question_ui_initialize.learnr_text <- function(question, value, ...) {
-  textInput(
+  # Use textInput() unless one of rows or cols are provided
+  textInputFn <- if (is.null(question$options$rows) && is.null(question$options$cols)) {
+    textInput
+  } else {
+    function(...) {
+      textAreaInput(..., cols = question$options$cols, rows = question$options$rows)
+    }
+  }
+
+  textInputFn(
     question$ids$answer,
     label = question$question,
     placeholder = question$options$placeholder,

--- a/man/question_text.Rd
+++ b/man/question_text.Rd
@@ -44,15 +44,11 @@ option.}
 
 \item{trim}{Logical to determine if whitespace before and after the answer should be removed.  Defaults to \code{TRUE}.}
 
-\item{rows}{The value of the visible character rows of the input, e.g. \code{6}.
-If the \code{height} argument is specified, \code{height} will take precedence in the
-browser's rendering.}
-
-\item{cols}{Value of the visible character columns of the input, e.g. \code{80}.
-This argument will only take effect if there is not a CSS \code{width} rule
-defined for this element; such a rule could come from the \code{width} argument
-of this function or from a containing page layout such as
-\code{\link[shiny:fluidPage]{fluidPage()}}.}
+\item{rows, cols}{Defines the size of the text input area in terms of the
+number of rows or character columns visible to the user. If either \code{rows}
+or \code{cols} are provided, the quiz input will use \code{\link[shiny:textAreaInput]{shiny::textAreaInput()}}
+for the text input, otherwise the default input element is a single-line
+\code{\link[shiny:textInput]{shiny::textInput()}}.}
 
 \item{options}{Extra options to be stored in the question object.}
 }

--- a/man/question_text.Rd
+++ b/man/question_text.Rd
@@ -14,6 +14,8 @@ question_text(
   random_answer_order = FALSE,
   placeholder = "Enter answer here...",
   trim = TRUE,
+  rows = NULL,
+  cols = NULL,
   options = list()
 )
 }
@@ -41,6 +43,16 @@ be entered into the control. Internet Explorer 8 and 9 do not support this
 option.}
 
 \item{trim}{Logical to determine if whitespace before and after the answer should be removed.  Defaults to \code{TRUE}.}
+
+\item{rows}{The value of the visible character rows of the input, e.g. \code{6}.
+If the \code{height} argument is specified, \code{height} will take precedence in the
+browser's rendering.}
+
+\item{cols}{Value of the visible character columns of the input, e.g. \code{80}.
+This argument will only take effect if there is not a CSS \code{width} rule
+defined for this element; such a rule could come from the \code{width} argument
+of this function or from a containing page layout such as
+\code{\link[shiny:fluidPage]{fluidPage()}}.}
 
 \item{options}{Extra options to be stored in the question object.}
 }

--- a/tests/testthat/test-question_text.R
+++ b/tests/testthat/test-question_text.R
@@ -1,0 +1,20 @@
+test_that("question text uses textAreaInput if rows or cols are provided", {
+  ans <- answer("", TRUE)
+
+  q_textArea_rows <- question_ui_initialize(question_text("A", ans, rows = 3), "")
+  expect_equal(q_textArea_rows$children[[2]]$name, "textarea")
+  expect_equal(q_textArea_rows$children[[2]]$attribs$rows, 3)
+
+  q_textArea_cols <- question_ui_initialize(question_text("A", ans, cols = 40), "")
+  expect_equal(q_textArea_cols$children[[2]]$name, "textarea")
+  expect_equal(q_textArea_cols$children[[2]]$attribs$cols, 40)
+
+  q_textArea <- question_ui_initialize(question_text("A", ans, rows = 4, cols = 30), "")
+  expect_equal(q_textArea$children[[2]]$name, "textarea")
+  expect_equal(q_textArea$children[[2]]$attribs$rows, 4)
+  expect_equal(q_textArea$children[[2]]$attribs$cols, 30)
+
+  q_text <- question_ui_initialize(question_text("A", ans), "")
+  expect_equal(q_text$children[[2]]$name, "input")
+  expect_equal(q_text$children[[2]]$attribs$type, "text")
+})


### PR DESCRIPTION
Fixes https://github.com/rstudio/learnr/issues/455

This PR adds `rows` and `cols` as parameters of `question_text()`. When provided, the text input UI will use `textAreaInput()` instead of `textInput()`.

I used `rows` and `cols` as the parameter names so we can inherit documentation from `textAreaInput()`, but I'd be happy to update the parameter names or documentation to specifically mention that they change the input UI.

### Reprex

Here's an example to try to create an "essay" input as described in #455. The question will always be graded as incorrect, but by setting `allow_retry = TRUE` and changing the `try_again_button` text, the input feels less binary correct/incorrect.

````
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)
```

## Text Questions

```{r question-text}
question_text("What's the best number of them all?", answer("42", TRUE))
```

```{r question-text-area}
question_text(
  "Why?", 
  answer("", correct = TRUE), # Question will always be "incorrect"
  rows = 5, 
  correct = NULL,
  incorrect = NULL,
  allow_retry = TRUE,
  try_again_button = "Edit Answer"
)
```
````

PR task list:
- [x] Update NEWS
- [x] Add tests (if possible)
- [x] Update documentation with `devtools::document()`
