### PR TITLE
Optionally reveal (or hide) exercise solution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@ learnr (development version)
 * Hitting the `TAB` key in an exercise has always opened the auto-completion drop down. Now, hitting the `TAB` key will also complete the currently selected code completion. ([#428](https://github.com/rstudio/learnr/pull/428))
 * `question_text()` gains `rows` and `cols` parameters. If either is provided, a multi-line `textAreaInput()` is used for the text input. ([#460](https://github.com/rstudio/learnr/pull/460), [#455](https://github.com/rstudio/learnr/issues/455))
 * Feedback messages can now be an htmltools tag or tagList, or a character message ([#458](https://github.com/rstudio/learnr/pull/458))
-* Added an option to reveal (or hide) the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. In a future version of learnr, the default will be changed to hide solutions. ([#402](https://github.com/rstudio/learnr/issue/402))
+* Added an option to reveal [default] (or hide) the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. In a future version of learnr, the default will be changed to hide solutions. ([#402](https://github.com/rstudio/learnr/issue/402))
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@ learnr (development version)
 * Hitting the `TAB` key in an exercise has always opened the auto-completion drop down. Now, hitting the `TAB` key will also complete the currently selected code completion. ([#428](https://github.com/rstudio/learnr/pull/428))
 * `question_text()` gains `rows` and `cols` parameters. If either is provided, a multi-line `textAreaInput()` is used for the text input. ([#460](https://github.com/rstudio/learnr/pull/460), [#455](https://github.com/rstudio/learnr/issues/455))
 * Feedback messages can now be an htmltools tag or tagList, or a character message ([#458](https://github.com/rstudio/learnr/pull/458))
-* Added an option to reveal (or hide) the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. ([#402](https://github.com/rstudio/learnr/issue/402))
+* Added an option to reveal (or hide) the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. In a future version of learnr, the default will be changed to hide solutions. ([#402](https://github.com/rstudio/learnr/issue/402))
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ learnr (development version)
 * Hitting the `TAB` key in an exercise has always opened the auto-completion drop down. Now, hitting the `TAB` key will also complete the currently selected code completion. ([#428](https://github.com/rstudio/learnr/pull/428))
 * `question_text()` gains `rows` and `cols` parameters. If either is provided, a multi-line `textAreaInput()` is used for the text input. ([#460](https://github.com/rstudio/learnr/pull/460), [#455](https://github.com/rstudio/learnr/issues/455))
 * Feedback messages can now be an htmltools tag or tagList, or a character message ([#458](https://github.com/rstudio/learnr/pull/458))
+* Added an option to reveal (or hide) the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. ([#402](https://github.com/rstudio/learnr/issue/402))
 
 ## Bug fixes
 

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -47,7 +47,7 @@ install_knitr_hooks <- function() {
         TRUE
       } else {
         # if this looks like a setup chunk, but no one references it, error
-        if (is.null(options$exercise) && !is.null(options$exercise.setup)) {
+        if (is.null(options[["exercise"]]) && !is.null(options$exercise.setup)) {
           stop(
             "Chunk '", options$label, "' is not being used by any exercise or exercise setup chunk.\n",
             "Please remove chunk '", options$label, "' or reference '", options$label, "' with `exercise.setup = '", options$label, "'`",
@@ -392,8 +392,16 @@ install_knitr_hooks <- function() {
 
       # send hint and solution to the browser
       # these are visibly displayed in the UI
-      if (is_exercise_support_chunk(options, type = c("hint", "hint-\\d+", "solution"))) {
+      if (is_exercise_support_chunk(options, type = c("hint", "hint-\\d+"))) {
         exercise_wrapper_div(suffix = "support")
+      }
+
+      if (is_exercise_support_chunk(options, type = "solution")) {
+        reveal_solution <- options$exercise.reveal_solution %||%
+          getOption("tutorial.exercise.reveal_solution", TRUE)
+        if (isTRUE(reveal_solution)) {
+          exercise_wrapper_div(suffix = "support")
+        }
       }
 
     }

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -150,9 +150,9 @@ install_knitr_hooks <- function() {
     # Determine if we should reveal the solution using...
     reveal_solution <-
       # 1. the option explicitly set on the solution chunk
-      eval(sol_opts_user$exercise.reveal_solution) %||%
+      eval(sol_opts_user$exercise.reveal_solution, envir = knitr::knit_global()) %||%
       # 2. the option explicitly set on the exercise chunk
-      eval(exercise_opts$exercise.reveal_solution) %||%
+      eval(exercise_opts$exercise.reveal_solution, envir = knitr::knit_global()) %||%
       # 3. the global knitr chunk option
       solution_opts$exercise.reveal_solution %||%
       # 4. the global R option

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -189,6 +189,12 @@ install_knitr_hooks <- function() {
       options$include <- FALSE
     }
 
+    if (is_exercise_support_chunk(options, type = "solution")) {
+      # only print solution if exercise.reveal_solution is TRUE
+      options$echo <- options$exercise.reveal_solution %||%
+        getOption("tutorial.exercise.reveal_solution", TRUE)
+    }
+
     # if this is an exercise setup chunk then eval it if the corresponding
     # exercise chunk is going to be executed
     if (exercise_setup_chunk) {
@@ -394,9 +400,7 @@ install_knitr_hooks <- function() {
       # these are visibly displayed in the UI
       if (is_exercise_support_chunk(options, type = c("hint", "hint-\\d+"))) {
         exercise_wrapper_div(suffix = "support")
-      }
-
-      if (is_exercise_support_chunk(options, type = "solution")) {
+      } else if (is_exercise_support_chunk(options, type = "solution")) {
         reveal_solution <- options$exercise.reveal_solution %||%
           getOption("tutorial.exercise.reveal_solution", TRUE)
         if (isTRUE(reveal_solution)) {

--- a/R/options.R
+++ b/R/options.R
@@ -18,6 +18,8 @@
 #' @param exercise.completion Use code completion in exercise editors.
 #' @param exercise.diagnostics Show diagnostics in exercise editors.
 #' @param exercise.startover Show "Start Over" button on exercise.
+#' @param exercise.reveal_solution Whether to reveal the exercise solution if
+#'   a solution chunk is provided.
 #'
 #' @export
 tutorial_options <- function(exercise.cap = NULL,
@@ -28,7 +30,8 @@ tutorial_options <- function(exercise.cap = NULL,
                              exercise.error.check.code = NULL,
                              exercise.completion = TRUE,
                              exercise.diagnostics = TRUE,
-                             exercise.startover = TRUE)
+                             exercise.startover = TRUE,
+                             exercise.reveal_solution = TRUE)
 {
   # string to evalute for setting chunk options  %1$s
   set_option_code <- 'if (!missing(%1$s)) knitr::opts_chunk$set(%1$s = %1$s)'
@@ -43,4 +46,5 @@ tutorial_options <- function(exercise.cap = NULL,
   eval(parse(text = sprintf(set_option_code, "exercise.completion")))
   eval(parse(text = sprintf(set_option_code, "exercise.diagnostics")))
   eval(parse(text = sprintf(set_option_code, "exercise.startover")))
+  eval(parse(text = sprintf(set_option_code, "exercise.reveal_solution")))
 }

--- a/docs/exercises.Rmd
+++ b/docs/exercises.Rmd
@@ -54,6 +54,10 @@ Exercises are interactive R code chunks that allow readers to directly execute R
 <td><code>exercise.warn_invisible</code></td>
 <td>Whether to display an invisible result warning if the last value returned is invisible.</td>
 </tr>
+<tr class="odd">
+<td><code>exercise.reveal_solution</code></td>
+<td>Whether or not the solution should be revealed to the user (defaults to `TRUE`). Set in the [solution chunk options](#hiding-solutions).</td>
+</tr>
 </tbody>
 </table>
 
@@ -144,7 +148,7 @@ For R code hints you can provide a sequence of hints that reveal progressively m
 
 ### Hiding Solutions
 
-By default, the exercise solution is always shown, although if there are hints those will appear first. If you would prefer not to reveal the solution to an exercise, you can disable the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of the `*-solution` chunk.
+By default, the exercise solution is made available to the user with the "Solution" or "Hint" button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of the `*-solution` chunk.
 
 <div id="exercisesolutionhidden"></div>
 <script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>

--- a/docs/exercises.Rmd
+++ b/docs/exercises.Rmd
@@ -153,7 +153,7 @@ By default, the exercise solution is made available to the user with the "Soluti
 <div id="exercisesolutionhidden"></div>
 <script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>
 
-You can also set this option globally in the global `setup` chunk with `tutorial_options()`. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise.
+You can also set this option globally in the global `setup` chunk with `tutorial_options()`. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise. The current default is to reveal exercise solutions, but in a future version of learnr the default behavior will change to hide solutions.
 
 ## Progressive Reveal
 

--- a/docs/exercises.Rmd
+++ b/docs/exercises.Rmd
@@ -142,6 +142,15 @@ For R code hints you can provide a sequence of hints that reveal progressively m
 <div id="exercisehints"></div>
 <script type="text/javascript">loadSnippet('exercisehints')</script>
 
+### Hiding Solutions
+
+By default, the exercise solution is always shown, although if there are hints those will appear first. If you would prefer not to reveal the solution to an exercise, you can disable the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of the `*-solution` chunk.
+
+<div id="exercisesolutionhidden"></div>
+<script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>
+
+You can also set this option globally in the global `setup` chunk with `tutorial_options()`. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise.
+
 ## Progressive Reveal
 
 You might want users of your tutorials to see only one sub-topic at a time as they work through the material (this can be helpful to reduce distractions and maintain focus on the current task). If you specify the `progressive` option then all Level 3 headings (`###`) will be revealed progressively. For example:

--- a/docs/exercises.Rmd
+++ b/docs/exercises.Rmd
@@ -56,7 +56,7 @@ Exercises are interactive R code chunks that allow readers to directly execute R
 </tr>
 <tr class="odd">
 <td><code>exercise.reveal_solution</code></td>
-<td>Whether or not the solution should be revealed to the user (defaults to `TRUE`). Set in the [solution chunk options](#hiding-solutions).</td>
+<td>Whether or not the solution should be revealed to the user (defaults to `TRUE`). See [Hiding Solutions](#hiding-solutions) below.</td>
 </tr>
 </tbody>
 </table>
@@ -148,7 +148,7 @@ For R code hints you can provide a sequence of hints that reveal progressively m
 
 ### Hiding Solutions
 
-By default, the exercise solution is made available to the user with the "Solution" or "Hint" button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of the `*-solution` chunk.
+By default, the exercise solution is made available to the user with the "Solution" or "Hint" button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of either the exercise or its corresponding `*-solution` chunk.
 
 <div id="exercisesolutionhidden"></div>
 <script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>

--- a/docs/exercises.html
+++ b/docs/exercises.html
@@ -513,6 +513,14 @@ Whether to include a “Start Over” button for the exercise.
 Whether to display an invisible result warning if the last value returned is invisible.
 </td>
 </tr>
+<tr class="odd">
+<td>
+<code>exercise.reveal_solution</code>
+</td>
+<td>
+Whether or not the solution should be revealed to the user (defaults to <code>TRUE</code>). Set in the <a href="#hiding-solutions">solution chunk options</a>.
+</td>
+</tr>
 </tbody>
 </table>
 <p>Note that these options can all be specified either globally or per-chunk. For example, the following code sets global default options using the <code>setup</code> chunk and also sets some local options on the <code>addition</code> chunk:</p>
@@ -600,7 +608,7 @@ Whether to display an invisible result warning if the last value returned is inv
 </div>
 <div id="hiding-solutions" class="section level3">
 <h3>Hiding Solutions</h3>
-<p>By default, the exercise solution is always shown, although if there are hints those will appear first. If you would prefer not to reveal the solution to an exercise, you can disable the solution by adding <code>exercise.reveal_solution = FALSE</code> to the chunk options of the <code>*-solution</code> chunk.</p>
+<p>By default, the exercise solution is made available to the user with the “Solution” or “Hint” button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding <code>exercise.reveal_solution = FALSE</code> to the chunk options of the <code>*-solution</code> chunk.</p>
 <div id="exercisesolutionhidden">
 
 </div>

--- a/docs/exercises.html
+++ b/docs/exercises.html
@@ -598,6 +598,15 @@ Whether to display an invisible result warning if the last value returned is inv
 </div>
 <script type="text/javascript">loadSnippet('exercisehints')</script>
 </div>
+<div id="hiding-solutions" class="section level3">
+<h3>Hiding Solutions</h3>
+<p>By default, the exercise solution is always shown, although if there are hints those will appear first. If you would prefer not to reveal the solution to an exercise, you can disable the solution by adding <code>exercise.reveal_solution = FALSE</code> to the chunk options of the <code>*-solution</code> chunk.</p>
+<div id="exercisesolutionhidden">
+
+</div>
+<script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>
+<p>You can also set this option globally in the global <code>setup</code> chunk with <code>tutorial_options()</code>. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise.</p>
+</div>
 </div>
 <div id="progressive-reveal" class="section level2">
 <h2>Progressive Reveal</h2>

--- a/docs/exercises.html
+++ b/docs/exercises.html
@@ -518,7 +518,7 @@ Whether to display an invisible result warning if the last value returned is inv
 <code>exercise.reveal_solution</code>
 </td>
 <td>
-Whether or not the solution should be revealed to the user (defaults to <code>TRUE</code>). Set in the <a href="#hiding-solutions">solution chunk options</a>.
+Whether or not the solution should be revealed to the user (defaults to <code>TRUE</code>). See <a href="#hiding-solutions">Hiding Solutions</a> below.
 </td>
 </tr>
 </tbody>
@@ -608,12 +608,12 @@ Whether or not the solution should be revealed to the user (defaults to <code>TR
 </div>
 <div id="hiding-solutions" class="section level3">
 <h3>Hiding Solutions</h3>
-<p>By default, the exercise solution is made available to the user with the “Solution” or “Hint” button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding <code>exercise.reveal_solution = FALSE</code> to the chunk options of the <code>*-solution</code> chunk.</p>
+<p>By default, the exercise solution is made available to the user with the “Solution” or “Hint” button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding <code>exercise.reveal_solution = FALSE</code> to the chunk options of either the exercise or its corresponding <code>*-solution</code> chunk.</p>
 <div id="exercisesolutionhidden">
 
 </div>
 <script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>
-<p>You can also set this option globally in the global <code>setup</code> chunk with <code>tutorial_options()</code>. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise.</p>
+<p>You can also set this option globally in the global <code>setup</code> chunk with <code>tutorial_options()</code>. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise. The current default is to reveal exercise solutions, but in a future version of learnr the default behavior will change to hide solutions.</p>
 </div>
 </div>
 <div id="progressive-reveal" class="section level2">

--- a/docs/snippets/exercisesolutionhidden.md
+++ b/docs/snippets/exercisesolutionhidden.md
@@ -1,0 +1,16 @@
+```{r filter, exercise=TRUE}
+# filter the flights table to include only United and American flights
+flights
+```
+
+```{r filter-hint-1}
+filter(flights, ...)
+```
+
+```{r filter-hint-2}
+filter(flights, UniqueCarrier=="AA")
+```
+
+```{r filter-solution, exercise.reveal_solution = FALSE}
+filter(flights, UniqueCarrier=="AA" | UniqueCarrier=="UA")
+```

--- a/man/tutorial.Rd
+++ b/man/tutorial.Rd
@@ -58,7 +58,9 @@ method creates a paginated HTML table (note that this method is only valid
 for formats that produce HTML). In addition to the named methods you can
 also pass an arbitrary function to be used for printing data frames. You
 can disable the \code{df_print} behavior entirely by setting the option
-\code{rmarkdown.df_print} to \code{FALSE}.}
+\code{rmarkdown.df_print} to \code{FALSE}. See
+\href{https://bookdown.org/yihui/rmarkdown/html-document.html#data-frame-printing}{Data
+frame printing section} in bookdown book for examples.}
 
 \item{smart}{Produce typographically correct output, converting straight quotes to curly quotes,
 \code{---} to em-dashes, \code{--} to en-dashes, and \code{...} to ellipses.

--- a/man/tutorial_options.Rd
+++ b/man/tutorial_options.Rd
@@ -13,7 +13,8 @@ tutorial_options(
   exercise.error.check.code = NULL,
   exercise.completion = TRUE,
   exercise.diagnostics = TRUE,
-  exercise.startover = TRUE
+  exercise.startover = TRUE,
+  exercise.reveal_solution = TRUE
 )
 }
 \arguments{
@@ -39,6 +40,9 @@ code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_cod
 \item{exercise.diagnostics}{Show diagnostics in exercise editors.}
 
 \item{exercise.startover}{Show "Start Over" button on exercise.}
+
+\item{exercise.reveal_solution}{Whether to reveal the exercise solution if
+a solution chunk is provided.}
 }
 \description{
 Set various tutorial options that control the display and evaluation of

--- a/tests/testthat/test-chunks-error-check.R
+++ b/tests/testthat/test-chunks-error-check.R
@@ -1,13 +1,15 @@
 test_that("*-error-check chunks require *-check chunks", {
-  skip_on_cran()
+  skip_if_not(rmarkdown::pandoc_available())
+
+  tmpfile <- tempfile(fileext = ".html")
+  on.exit(unlink(tmpfile))
+
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "error-check-chunk_bad.Rmd"), render_args = list(quiet = TRUE)),
+    rmarkdown::render(test_path("setup-chunks", "error-check-chunk_bad.Rmd"), output_file = tmpfile, quiet = TRUE),
     "ex-check",
     fixed = TRUE
   )
 
-  tmpfile <- tempfile(fileext = ".html")
-  on.exit(unlink(tmpfile))
   expect_silent(
     rmarkdown::render(test_path("setup-chunks", "error-check-chunk_good.Rmd"), output_file = tmpfile, quiet = TRUE)
   )

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -1,0 +1,49 @@
+context("Optionally reveal solution")
+
+render_tutorial_with_reveal_solution <- function(opt_string) {
+  ex <- readLines(test_path("tutorials", "optional-show-solution.Rmd"))
+  ex <- sub("#<<reveal_solution>>", opt_string, ex, fixed = TRUE)
+
+  tut_rmd <- tempfile(fileext = ".Rmd")
+  writeLines(ex, tut_rmd)
+  tut_html <- rmarkdown::render(tut_rmd, quiet = TRUE)
+  on.exit({
+    rmarkdown::shiny_prerendered_clean(tut_rmd)
+    unlink(tut_html)
+    unlink(tut_rmd)
+  })
+
+  paste(readLines(tut_html), collapse = "\n")
+}
+
+default_solution <- "<code># DEFAULT SOLUTION 4631b0</code>"
+hidden_solution <- "<code># HIDDEN SOLUTION 48da3c</code>"
+shown_solution <- "<code># SHOWN SOLUTION 781cbb</code>"
+
+test_that("Solutions are revealed or hidden with tutorial_options()", {
+  skip_if_not(rmarkdown::pandoc_available("1.12.3"))
+
+  ex_show <- render_tutorial_with_reveal_solution("tutorial_options(exercise.reveal_solution = TRUE)")
+  expect_match(ex_show, default_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
+  expect_match(ex_show, shown_solution, fixed = TRUE)
+
+  ex_hide <- render_tutorial_with_reveal_solution("tutorial_options(exercise.reveal_solution = FALSE)")
+  expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
+  expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
+  expect_match(ex_hide, shown_solution, fixed = TRUE)
+})
+
+test_that("Solutions are revealed or hidden with global option", {
+  skip_if_not(rmarkdown::pandoc_available("1.12.3"))
+
+  ex_show <- render_tutorial_with_reveal_solution("options(tutorial.exercise.reveal_solution = TRUE)")
+  expect_match(ex_show, default_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
+  expect_match(ex_show, shown_solution, fixed = TRUE)
+
+  ex_hide <- render_tutorial_with_reveal_solution("options(tutorial.exercise.reveal_solution = FALSE)")
+  expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
+  expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
+  expect_match(ex_hide, shown_solution, fixed = TRUE)
+})

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -21,6 +21,7 @@ render_tutorial_with_reveal_solution <- function(opt_string) {
 default_solution <- "<code># DEFAULT SOLUTION 4631b0</code>"
 hidden_solution <- "<code># HIDDEN SOLUTION 48da3c</code>"
 shown_solution <- "<code># SHOWN SOLUTION 781cbb</code>"
+ex_opt_solution <- "<code># EXERCISE OPT SOLUTION 15c861</code>"
 
 test_that("Solutions are revealed or hidden with tutorial_options()", {
   skip_if_not(rmarkdown::pandoc_available())
@@ -29,11 +30,13 @@ test_that("Solutions are revealed or hidden with tutorial_options()", {
   expect_match(ex_show, default_solution, fixed = TRUE)
   expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
   expect_match(ex_show, shown_solution, fixed = TRUE)
+  expect_match(ex_show, ex_opt_solution, fixed = TRUE)
 
   ex_hide <- render_tutorial_with_reveal_solution("tutorial_options(exercise.reveal_solution = FALSE)")
   expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
   expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
   expect_match(ex_hide, shown_solution, fixed = TRUE)
+  expect_match(ex_hide, ex_opt_solution, fixed = TRUE)
 })
 
 test_that("Solutions are revealed or hidden with global option", {
@@ -43,9 +46,11 @@ test_that("Solutions are revealed or hidden with global option", {
   expect_match(ex_show, default_solution, fixed = TRUE)
   expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
   expect_match(ex_show, shown_solution, fixed = TRUE)
+  expect_match(ex_show, ex_opt_solution, fixed = TRUE)
 
   ex_hide <- render_tutorial_with_reveal_solution("options(tutorial.exercise.reveal_solution = FALSE)")
   expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
   expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
   expect_match(ex_hide, shown_solution, fixed = TRUE)
+  expect_match(ex_hide, ex_opt_solution, fixed = TRUE)
 })

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -5,13 +5,15 @@ render_tutorial_with_reveal_solution <- function(opt_string) {
   ex <- sub("#<<reveal_solution>>", opt_string, ex, fixed = TRUE)
 
   tut_rmd <- tempfile(fileext = ".Rmd")
+  on.exit(unlink(tut_rmd))
+
   writeLines(ex, tut_rmd)
   tut_html <- rmarkdown::render(tut_rmd, quiet = TRUE)
+
   on.exit({
     rmarkdown::shiny_prerendered_clean(tut_rmd)
     unlink(tut_html)
-    unlink(tut_rmd)
-  })
+  }, add = TRUE, after = FALSE)
 
   paste(readLines(tut_html), collapse = "\n")
 }

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -24,6 +24,8 @@ default_solution <- "<code># DEFAULT SOLUTION 4631b0</code>"
 hidden_solution <- "<code># HIDDEN SOLUTION 48da3c</code>"
 shown_solution <- "<code># SHOWN SOLUTION 781cbb</code>"
 ex_opt_solution <- "<code># EXERCISE OPT SOLUTION 15c861</code>"
+var_hide_solution <- "<code># HIDDEN VAR SOLUTION 0b219b</code>"
+var_show_solution <- "<code># SHOWN VAR SOLUTION aba888</code>"
 
 test_that("Solutions are revealed or hidden with tutorial_options()", {
   skip_if_not(rmarkdown::pandoc_available())
@@ -33,12 +35,16 @@ test_that("Solutions are revealed or hidden with tutorial_options()", {
   expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
   expect_match(ex_show, shown_solution, fixed = TRUE)
   expect_match(ex_show, ex_opt_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_show, var_hide_solution, fixed = TRUE))
+  expect_match(ex_show, var_show_solution, fixed = TRUE)
 
   ex_hide <- render_tutorial_with_reveal_solution("tutorial_options(exercise.reveal_solution = FALSE)")
   expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
   expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
   expect_match(ex_hide, shown_solution, fixed = TRUE)
   expect_match(ex_hide, ex_opt_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_hide, var_hide_solution, fixed = TRUE))
+  expect_match(ex_hide, var_show_solution, fixed = TRUE)
 })
 
 test_that("Solutions are revealed or hidden with global option", {
@@ -49,10 +55,14 @@ test_that("Solutions are revealed or hidden with global option", {
   expect_failure(expect_match(ex_show, hidden_solution, fixed = TRUE))
   expect_match(ex_show, shown_solution, fixed = TRUE)
   expect_match(ex_show, ex_opt_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_show, var_hide_solution, fixed = TRUE))
+  expect_match(ex_show, var_show_solution, fixed = TRUE)
 
   ex_hide <- render_tutorial_with_reveal_solution("options(tutorial.exercise.reveal_solution = FALSE)")
   expect_failure(expect_match(ex_hide, default_solution, fixed = TRUE))
   expect_failure(expect_match(ex_hide, hidden_solution, fixed = TRUE))
   expect_match(ex_hide, shown_solution, fixed = TRUE)
   expect_match(ex_hide, ex_opt_solution, fixed = TRUE)
+  expect_failure(expect_match(ex_hide, var_hide_solution, fixed = TRUE))
+  expect_match(ex_hide, var_show_solution, fixed = TRUE)
 })

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -10,10 +10,12 @@ render_tutorial_with_reveal_solution <- function(opt_string) {
   writeLines(ex, tut_rmd)
   tut_html <- rmarkdown::render(tut_rmd, quiet = TRUE)
 
+  # overwrite exit handler to remove all tutorial files
   on.exit({
     rmarkdown::shiny_prerendered_clean(tut_rmd)
     unlink(tut_html)
-  }, add = TRUE, after = FALSE)
+    unlink(tut_rmd)
+  }, add = FALSE)
 
   paste(readLines(tut_html), collapse = "\n")
 }

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -21,7 +21,7 @@ hidden_solution <- "<code># HIDDEN SOLUTION 48da3c</code>"
 shown_solution <- "<code># SHOWN SOLUTION 781cbb</code>"
 
 test_that("Solutions are revealed or hidden with tutorial_options()", {
-  skip_if_not(rmarkdown::pandoc_available("1.12.3"))
+  skip_if_not(rmarkdown::pandoc_available())
 
   ex_show <- render_tutorial_with_reveal_solution("tutorial_options(exercise.reveal_solution = TRUE)")
   expect_match(ex_show, default_solution, fixed = TRUE)
@@ -35,7 +35,7 @@ test_that("Solutions are revealed or hidden with tutorial_options()", {
 })
 
 test_that("Solutions are revealed or hidden with global option", {
-  skip_if_not(rmarkdown::pandoc_available("1.12.3"))
+  skip_if_not(rmarkdown::pandoc_available())
 
   ex_show <- render_tutorial_with_reveal_solution("options(tutorial.exercise.reveal_solution = TRUE)")
   expect_match(ex_show, default_solution, fixed = TRUE)

--- a/tests/testthat/test-setup-chunks.R
+++ b/tests/testthat/test-setup-chunks.R
@@ -1,37 +1,41 @@
 test_that("Detection of chained setup cycle works", {
-  skip_on_cran()
+  skip_if_not(rmarkdown::pandoc_available())
+
+  tmpfile <- tempfile(fileext = ".html")
+  on.exit(unlink(tmpfile))
+
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "setup-cycle.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "setup-cycle.Rmd"), output_file = tmpfile, quiet = TRUE),
     "dataA => dataC => dataB => dataA",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "setup-cycle-self.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "setup-cycle-self.Rmd"), output_file = tmpfile, quiet = TRUE),
     "dataA => dataA",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "setup-cycle-two.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "setup-cycle-two.Rmd"), output_file = tmpfile, quiet = TRUE),
     "dataA => dataB => dataA",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "exercise-cycle-default-setup.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "exercise-cycle-default-setup.Rmd"), output_file = tmpfile, quiet = TRUE),
     "data1 => data1-setup => data1",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "exercise-cycle.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "exercise-cycle.Rmd"), output_file = tmpfile, quiet = TRUE),
     "data1 => data3 => data2 => data1",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "exercise-cycle-self.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "exercise-cycle-self.Rmd"), output_file = tmpfile, quiet = TRUE),
     "data1 => data1",
     fixed = TRUE
   )
   expect_error(
-    rmarkdown::run(test_path("setup-chunks", "exercise-cycle-two.Rmd")),
+    rmarkdown::render(test_path("setup-chunks", "exercise-cycle-two.Rmd"), output_file = tmpfile, quiet = TRUE),
     "data1 => data2 => data1",
     fixed = TRUE
   )

--- a/tests/testthat/tutorials/optional-show-solution.Rmd
+++ b/tests/testthat/tutorials/optional-show-solution.Rmd
@@ -17,9 +17,7 @@ library(learnr)
 
 ### Default
 
-<!-- exercise.reveal_solution needs to be on solution chunk -->
-
-```{r default, exercise = TRUE, exercise.reveal_solution = TRUE}
+```{r default, exercise = TRUE}
 1 + 1
 ```
 
@@ -35,9 +33,27 @@ library(learnr)
 # DEFAULT SOLUTION 4631b0
 ```
 
+### Reveal Set on Exercise
+
+```{r set-on-ex, exercise = TRUE, exercise.reveal_solution = TRUE}
+1 + 1
+```
+
+```{r set-on-ex-hint-1}
+# EXERCISE OPT HINT 1
+```
+
+```{r set-on-ex-hint-2}
+# EXERCISE OPT HINT 2
+```
+
+```{r set-on-ex-solution}
+# EXERCISE OPT SOLUTION 15c861
+```
+
 ### Always Hides Solution
 
-```{r hide, exercise = TRUE}
+```{r hide, exercise = TRUE, exercise.reveal_solution = TRUE}
 1 + 1
 ```
 
@@ -55,7 +71,7 @@ library(learnr)
 
 ### Always Shows Solution
 
-```{r show, exercise = TRUE}
+```{r show, exercise = TRUE, exercise.reveal_solution = FALSE}
 1 + 1
 ```
 

--- a/tests/testthat/tutorials/optional-show-solution.Rmd
+++ b/tests/testthat/tutorials/optional-show-solution.Rmd
@@ -7,6 +7,9 @@ runtime: shiny_prerendered
 ```{r setup, include=FALSE}
 library(learnr)
 
+HIDE_SOLUTION <- FALSE
+SHOW_SOLUTION <- TRUE
+
 # Set global option reveal solution option
 # options(tutorial.exercise.reveal_solution = FALSE)
 # tutorial_options(exercise.reveal_solution = TRUE)
@@ -85,4 +88,24 @@ library(learnr)
 
 ```{r show-solution, exercise.reveal_solution = TRUE}
 # SHOWN SOLUTION 781cbb
+```
+
+### Hidden Using Variable in Chunk Opt
+
+```{r var-hide, exercise = TRUE, exercise.reveal_solution = HIDE_SOLUTION}
+1 + 1
+```
+
+```{r var-hide-solution}
+# HIDDEN VAR SOLUTION 0b219b
+```
+
+### Shown Using Variable in Chunk Opt
+
+```{r var-shown, exercise = TRUE, exercise.reveal_solution = SHOW_SOLUTION}
+1 + 1
+```
+
+```{r var-shown-solution}
+# SHOWN VAR SOLUTION aba888
 ```

--- a/tests/testthat/tutorials/optional-show-solution.Rmd
+++ b/tests/testthat/tutorials/optional-show-solution.Rmd
@@ -1,0 +1,72 @@
+---
+title: "Optionally Reveal Exercise Solution"
+output: learnr::tutorial
+runtime: shiny_prerendered
+---
+
+```{r setup, include=FALSE}
+library(learnr)
+
+# Set global option reveal solution option
+# options(tutorial.exercise.reveal_solution = FALSE)
+# tutorial_options(exercise.reveal_solution = TRUE)
+#<<reveal_solution>>
+```
+
+## Intro
+
+### Default
+
+<!-- exercise.reveal_solution needs to be on solution chunk -->
+
+```{r default, exercise = TRUE, exercise.reveal_solution = TRUE}
+1 + 1
+```
+
+```{r default-hint-1}
+# DEFAULT HINT 1
+```
+
+```{r default-hint-2}
+# DEFAULT HINT 2
+```
+
+```{r default-solution}
+# DEFAULT SOLUTION 4631b0
+```
+
+### Always Hides Solution
+
+```{r hide, exercise = TRUE}
+1 + 1
+```
+
+```{r hide-hint-1}
+# HIDDEN HINT 1
+```
+
+```{r hide-hint-2}
+# HIDDEN HINT 2
+```
+
+```{r hide-solution, exercise.reveal_solution = FALSE}
+# HIDDEN SOLUTION 48da3c
+```
+
+### Always Shows Solution
+
+```{r show, exercise = TRUE}
+1 + 1
+```
+
+```{r show-hint-1}
+# SHOWN HINT 1
+```
+
+```{r show-hint-2}
+# SHOWN HINT 2
+```
+
+```{r show-solution, exercise.reveal_solution = TRUE}
+# SHOWN SOLUTION 781cbb
+```


### PR DESCRIPTION
Adds `exercise.reveal_solution`, which can be set in the `*-solution` chunk options or globally with `tutorial_options()` or `tutorial.exercise.reveal_solution`. If `FALSE`, the solution is not revealed to the user. The local chunk option takes precedence over the global option.

Fixes #402

<details><summary>Demo Tutorial</summary>

````markdown
---
title: "Optionally Reveal Exercise Solution"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)

## Set global reveal solution option
# options(tutorial.exercise.reveal_solution = FALSE)
# tutorial_options(exercise.reveal_solution = FALSE)
```

## Intro

### Default

<!-- exercise.reveal_solution needs to be on solution chunk -->

```{r default, exercise = TRUE, exercise.reveal_solution = TRUE}
1 + 1
```

```{r default-hint-1}
# hint code 1
```

```{r default-hint-2}
# hint code 2
```

```{r default-solution}
2
```

### Always Hides Solution

```{r hide, exercise = TRUE}
1 + 1
```

```{r hide-hint-1}
# hint code 1
```

```{r hide-hint-2}
# hint code 2
```

```{r hide-solution, exercise.reveal_solution = FALSE}
2
```

### Always Shows Solution

```{r show, exercise = TRUE}
1 + 1
```

```{r show-hint-1}
# hint code 1
```

```{r show-hint-2}
# hint code 2
```

```{r show-solution, exercise.reveal_solution = TRUE}
2
```

````

</details>

PR task list:
- [x] Update NEWS
- [x] Add tests (if possible)
- [x] Update documentation with `devtools::document()`
