### PR TITLE
Drop non-list HTML dependencies from exercise html_output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ learnr (development version)
 * Fail gracefully when unable to open an indexedDB store (e.g. in cross-origin iframes in Safari). ([#417](https://github.com/rstudio/learnr/issues/417)).
 * When a quiz's question or answer text are not characters, e.g. HTML, `htmltools` tags, numeric, etc., they are now cast to characters for the displayed answer text and the quiz's default loading text ([#450](https://github.com/rstudio/learnr/pull/450)).
 * The `envir_prep` environment used in exercise checking now captures the result of both global and exercise-specific setup code, representing the environment in which the user code will be evaluated as described in the documentation. We also ensure that `envir_result` (the environment containing the result of evaluating global, setup and user code) is a sibling of `envir_prep`. ([#480](https://github.com/rstudio/learnr/pull/480))
+* HTML dependencies of exercises run by users now excludes dependencies created with `htmltools::tags$head()`. (thanks @andysouth, [#484](https://github.com/rstudio/learnr/issues/484))
 
 learnr 0.10.1
 ===========

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -414,11 +414,11 @@ render_exercise <- function(exercise, envir) {
     })
 
     # Copy in a full clone `envir_prep` before running user code in `envir_result`
-    # By being a sibling to `envir_prep` (rather than a dependency), 
-    #   alterations to `envir_prep` from eval'ing code in `envir_result` 
+    # By being a sibling to `envir_prep` (rather than a dependency),
+    #   alterations to `envir_prep` from eval'ing code in `envir_result`
     #   are much more difficult
     envir_result <- duplicate_env(envir_prep)
-    
+
     # Now render user code for final result
     rmarkdown::render(
       input = rmd_file_user,
@@ -578,12 +578,13 @@ is_error_result <- function(x) {
 
 filter_dependencies <- function(dependencies) {
   # purge dependencies that aren't in a package (to close off reading of
-  # artibtary filesystem locations)
+  # arbitrary filesystem locations)
   Filter(x = dependencies, function(dependency) {
-    if (!is.null(dependency$package)) {
+    if (!is.list(dependency)) {
+      FALSE
+    } else if (!is.null(dependency$package)) {
       TRUE
-    }
-    else {
+    } else {
       ! is.null(tryCatch(
         rprojroot::find_root(rprojroot::is_r_package,
                              path = dependency$src$file),

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -218,3 +218,27 @@ test_that("serialized exercises produce equivalent evaluate_exercise() results",
     env_vals(ex_eval_rmote$feedback$checker_args$envir_result)
   )
 })
+
+# filter_dependencies() ---------------------------------------------------
+
+test_that("filter_dependencies() excludes non-list knit_meta objects", {
+  ex <- mock_exercise(
+    user_code = deparse(quote(
+      htmltools::tagList(
+        htmltools::tags$head(htmltools::tags$style(".leaflet-container {backround:#FFF}")),
+        learnr::html_dependency_jquery()
+      )
+    ))
+  )
+
+  ex_res <- expect_silent(render_exercise(ex, new.env()))
+
+  ex_res_html_deps <- htmltools::htmlDependencies(ex_res$html_output)
+  # The head(style) dependency is dropped because it's not from a package
+  expect_equal(length(ex_res_html_deps), 1L)
+  # But we keep the dependency that came from a pkg
+  expect_equal(
+    ex_res_html_deps[[1]],
+    learnr::html_dependency_jquery()
+  )
+})

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -226,7 +226,7 @@ test_that("filter_dependencies() excludes non-list knit_meta objects", {
     user_code = deparse(quote(
       htmltools::tagList(
         htmltools::tags$head(htmltools::tags$style(".leaflet-container {backround:#FFF}")),
-        learnr::html_dependency_jquery()
+        html_dependency_jquery()
       )
     ))
   )
@@ -239,6 +239,6 @@ test_that("filter_dependencies() excludes non-list knit_meta objects", {
   # But we keep the dependency that came from a pkg
   expect_equal(
     ex_res_html_deps[[1]],
-    learnr::html_dependency_jquery()
+    html_dependency_jquery()
   )
 })


### PR DESCRIPTION
Fixes #484

PR task list:
- [x] Update NEWS
- [x] Add tests (if possible)
- [x] Update documentation with `devtools::document()`
