### PR TITLE
Get timelimit from complete exercise object

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -18,8 +18,6 @@ setup_exercise_handler <- function(exercise_rx, session) {
 
     # get exercise from app
     exercise <- exercise_rx()
-    # merge with exercise object in cache to fill in all options
-    exercise <- utils::modifyList(exercise_cache_env[[exercise$label]], exercise)
 
     # short circuit for restore (we restore some outputs like errors so that
     # they are not re-executed when bringing the tutorial back up)
@@ -40,12 +38,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
         return()
       }
     }
-
-    # get timelimit option (either from chunk option or from global option)
-    timelimit <- exercise$options$exercise.timelimit
-    if (is.null(timelimit))
-      timelimit <- getOption("tutorial.exercise.timelimit", default = 30)
-
+    
     # get exercise evaluator factory function (allow replacement via global option)
     evaluator_factory <- getOption("tutorial.exercise.evaluator", default = NULL)
     if (is.null(evaluator_factory)) {
@@ -57,7 +50,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
       else
         evaluator_factory <- inline_evaluator
     }
-
+    
     # supplement the exercise with the global setup options
     # TODO: warn if falling back to the `setup` chunk with an out-of-process evaluator.
     exercise$global_setup <- get_global_setup()
@@ -69,6 +62,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
     exercise <- append(exercise, get_exercise_cache(exercise$label))
     # If there is no locally defined error check code, look for globally defined error check option
     exercise$error_check <- exercise$error_check %||% exercise$options$exercise.error.check.code
+    
     if (!isTRUE(exercise$should_check)) {
       exercise$check <- NULL
       exercise$code_check <- NULL
@@ -76,6 +70,11 @@ setup_exercise_handler <- function(exercise_rx, session) {
     }
     # variable has now served its purpose so remove it
     exercise$should_check <- NULL
+
+    # get timelimit option (either from chunk option or from global option)
+    timelimit <- exercise$options$exercise.timelimit
+    if (is.null(timelimit))
+      timelimit <- getOption("tutorial.exercise.timelimit", default = 30)
 
     # placeholder for current learnr version to deal with exercise structure differences
     # with other learnr versions

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -16,8 +16,10 @@ setup_exercise_handler <- function(exercise_rx, session) {
   # observe input
   observeEvent(exercise_rx(), {
 
-    # get exercise
+    # get exercise from app
     exercise <- exercise_rx()
+    # merge with exercise object in cache to fill in all options
+    exercise <- utils::modifyList(exercise_cache_env[[exercise$label]], exercise)
 
     # short circuit for restore (we restore some outputs like errors so that
     # they are not re-executed when bringing the tutorial back up)

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -38,7 +38,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
         return()
       }
     }
-    
+
     # get exercise evaluator factory function (allow replacement via global option)
     evaluator_factory <- getOption("tutorial.exercise.evaluator", default = NULL)
     if (is.null(evaluator_factory)) {
@@ -50,7 +50,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
       else
         evaluator_factory <- inline_evaluator
     }
-    
+
     # supplement the exercise with the global setup options
     # TODO: warn if falling back to the `setup` chunk with an out-of-process evaluator.
     exercise$global_setup <- get_global_setup()
@@ -62,7 +62,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
     exercise <- append(exercise, get_exercise_cache(exercise$label))
     # If there is no locally defined error check code, look for globally defined error check option
     exercise$error_check <- exercise$error_check %||% exercise$options$exercise.error.check.code
-    
+
     if (!isTRUE(exercise$should_check)) {
       exercise$check <- NULL
       exercise$code_check <- NULL


### PR DESCRIPTION
Edit: on second thought, we were just setting `timelimit` too early. Getting the timelimit after filling out the `exercise` object fixes the issue in #492.

This fixes #492. The exercise reactive returned by `` input$`tutorial-exercise-%s-code-editor` `` doesn't include all of the exercise options. It seems that `exercise_rx()` only contains the `label`, the submitted `code`, a `timestamp` and flags for `restore` and `should_check`. The result is that, when `setup_exercise_handler` tries to find `$options$exercise.timelimit`, that field is always `NULL` because `$options` isn't a item in the reactive exercise list.

~I'm not sure if that should be rectified in the exercise object logic, but~ I was able to fix the issue by merging the reactive exercise object with the cached exercise object that contains the complete options, check code, etc. (Edit: _which we do later so we were just setting `timelimit` too eary._)

Here's a reprex Rmd for testing. Prior to the change in this PR, learnr ignores both the chunk and global options and always caps exercises at 30 seconds. Both time-limit setting methods are demonstrated in the reprex.

````
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{js, echo=FALSE}
// custom message handler to report elapsed time
Shiny.addCustomMessageHandler('time', function(x) {
  document.getElementById('section-time').textContent = x
})
```

## Time Limit

```{r setup}
library(learnr)
tutorial_options(exercise.timelimit = 15)
```

The code has been running for <span id="time">0</span> seconds.

```{r ex-setup}
sleep <- function(n) {
  session <- shiny::getDefaultReactiveDomain()
  session$sendCustomMessage("time", 0)
  for (i in 1:n) {
    Sys.sleep(1)
    session$sendCustomMessage("time", i)
  }
}
```

```{r ex, exercise = TRUE, exercise.timelimit = 5}
sleep(15)
```
````

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
