### PR TITLE
Add tutorial id, version, and user_id to exercise object

### DIFF
--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -196,6 +196,10 @@ internal_external_evaluator <- function(
           if (identical(exercise$options$exercise.checker, "NULL")){
             exercise$options$exercise.checker <- c()
           }
+          if (!is.null(exercise$tutorial) && "user_id" %in% names(exercise$tutorial)) {
+            # Hide user_id from external evalutators
+            exercise$tutorial$user_id <- "learnr_user"
+          }
           json <- jsonlite::toJSON(exercise, auto_unbox = TRUE, null = "null")
 
           if (is.null(exercise$options$exercise.timelimit) || exercise$options$exercise.timelimit == 0){

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -196,10 +196,7 @@ internal_external_evaluator <- function(
           if (identical(exercise$options$exercise.checker, "NULL")){
             exercise$options$exercise.checker <- c()
           }
-          if (!is.null(exercise$tutorial) && "user_id" %in% names(exercise$tutorial)) {
-            # Hide user_id from external evalutators
-            exercise$tutorial$user_id <- "learnr_user"
-          }
+
           json <- jsonlite::toJSON(exercise, auto_unbox = TRUE, null = "null")
 
           if (is.null(exercise$options$exercise.timelimit) || exercise$options$exercise.timelimit == 0){

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -160,29 +160,97 @@ setup_exercise_handler <- function(exercise_rx, session) {
   })
 }
 
-# helper function that will upgrade a previous learnr exercise into new learnr exercise
-# TODO: do the actual upgrade
-upgrade_exercise <- function(exercise) {
-  # if version doesn't exist we're at "0" (older learnr)
-  if (is.null(exercise$version)) {
-    exercise$version <- "0"
+# This function exists to synchronize versions of the exercise objects in case
+# an exercise created with an older version of {learnr} is evaluated by a
+# newer version of {learnr}. This may be the case when there is a version
+# mismatch between the version used to serve the tutorial and the version used
+# to evaluate the exercise (external evaluator).
+upgrade_exercise <- function(exercise, require_items = NULL) {
+  if (identical(exercise$version, current_exercise_version)) {
+    return(exercise)
   }
-  # for now, raise error when learnr version is not supported
-  # else, return the exercise for the correct version, "1"
-  switch(exercise$version,
-    "0" = stop("Exercise version not supplied! Unable to upgrade exercise."),
-    "1" = {
-      # upgrade exercise with tutorial information
-      exercise$tutorial <- list(
-        tutorial_id = "tutorial_id:UPGRADE learnr",
-        tutorial_version = "-1",
-        user_id = "user_id:UPGRADE learnr"
-      )
-      exercise
-    },
-    "2" = exercise,
-    stop("Exercise version unknown. Unable to upgrade exercise.")
+
+  if (!is.null(exercise$version)) {
+    exercise$version <- suppressWarnings(as.numeric(exercise$version))
+  }
+
+  if (
+    is.null(exercise$version) ||
+      is.na(exercise$version) ||
+      length(exercise$version) != 1 ||
+      identical(paste(exercise$version), "0")
+  ) {
+    v <- if (is.null(exercise$version)) {
+      "an undefined version"
+    } else if (is.na(exercise$version) || length(exercise$version) != 1) {
+      "an incorrectly formatted version"
+    } else {
+      'version "0"'
+    }
+
+    stop(
+      "Received an exercise with ", v, ", most likely because it's ",
+      "from an older version of {learnr}. This is {learnr} version ",
+      utils::packageVersion("learnr")
+    )
+  }
+
+  current_version <- as.numeric(current_exercise_version)
+
+  if (exercise$version == 1) {
+    # exercise version 2 added $tutorial information
+    exercise$tutorial <- list(
+      tutorial_id = "tutorial_id:UPGRADE learnr",
+      tutorial_version = "-1",
+      user_id = "user_id:UPGRADE learnr"
+    )
+    exercise$version <- 2
+    exercise
+  }
+
+  # Future logic to upgrade an exercise from version 2 to version N goes here...
+
+  if (identical(exercise$version, current_version)) {
+    return(exercise)
+  }
+
+  # What if we get an exercise from the future? We'll try to have backwards
+  # compatibility with the exercise object. But validate_exercise() will find
+  # any catastrophic problems that are incompatible with the _current_ version
+  exercise_problem <- validate_exercise(exercise, require_items)
+
+  if (is.null(exercise_problem)) {
+    # The exercise may not evaluate perfectly, but it's likely that evaluating
+    # this exercise will work out. Or at least won't result in surfacing an
+    # internal learnr error as the culprit.
+    warning(
+      "Expected exercise version ", current_version, ", but received version ",
+      exercise$version, ". This version of {learnr} is likely able to evaluate ",
+      "version ", exercise$version, " exercises, but there may be differences. ",
+      "Please upgrade {learnr}; this version is ",
+      utils::packageVersion("learnr"), "."
+    )
+    return(exercise)
+  }
+
+  stop(
+    "Expected exercise version ", current_version, ", but received version ",
+    exercise$version, ". These versions are incompatible. ", exercise_problem
   )
+}
+
+# The current version of the exercise object will produce _very wrong_ or _very
+# surprising_ results if it doesn't pass this validation check. This function
+# returns NULL if everything is okay, otherwise a character string describing
+# the reason the validation check failed.
+validate_exercise <- function(exercise, require_items = NULL) {
+required_names <- c("code", "label", "options", "chunks", require_items)
+  missing_names <- setdiff(required_names, names(exercise))
+  if (length(missing_names)) {
+    return(paste("Missing exercise items:", paste(missing_names, collapse = ", ")))
+  }
+
+  NULL
 }
 
 # evaluate an exercise and return a list containing output and dependencies
@@ -197,8 +265,11 @@ upgrade_exercise <- function(exercise) {
 #   global setup.
 evaluate_exercise <- function(exercise, envir, evaluate_global_setup = FALSE) {
 
-  # for compatibility with previous learnr versions, we'll upgrade exercise (if possible)
-  exercise <- upgrade_exercise(exercise)
+  # adjust exercise version to match the current learnr version
+  exercise <- upgrade_exercise(
+    exercise,
+    require_items = if (evaluate_global_setup) "global_setup"
+  )
 
   # return immediately and clear visible results
   # do not consider this an exercise submission

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -23,7 +23,8 @@ setup_exercise_handler <- function(exercise_rx, session) {
     exercise$tutorial <- list(
       tutorial_id = read_request(session, "tutorial.tutorial_id"),
       tutorial_version = read_request(session, "tutorial.tutorial_version"),
-      user_id = read_request(session, "tutorial.user_id")
+      user_id = read_request(session, "tutorial.user_id"),
+      learnr_version = utils::packageVersion("learnr")
     )
 
     # short circuit for restore (we restore some outputs like errors so that

--- a/R/identifiers.R
+++ b/R/identifiers.R
@@ -26,59 +26,76 @@ initialize_session_state <- function(session, metadata, location, request) {
     value
   }
 
-  # determine if we are running inside a package
-  cwd <- getwd()
-  package_dir <- tryCatch(rprojroot::find_root(rprojroot::is_r_package,
-                                               path = cwd),
-                          error = function(e) NULL)
-  if (!is.null(package_dir)) {
-    package_desc <- file.path(package_dir, "DESCRIPTION")
-    package_info <- read.dcf(package_desc, all = TRUE)
-  }
-
-  # determine default tutorial id (metadata first then filesystem-based for
-  # localhost and remote URL based for other configurations)
-  default_tutorial_id <- metadata$id
-  if (is.null(default_tutorial_id)) {
-    if (is_localhost(location)) {
-      if (!is.null(package_dir)) {
-        default_tutorial_id <- sprintf("package:%s-%s",
-                                       package_info$Package,
-                                       sub(paste0("^", package_dir), "", cwd))
-      }
-      else {
-        default_tutorial_id <- cwd
-      }
-    }
-    else {
-      default_tutorial_id <- paste0(location$host, location$pathname)
-    }
-  }
-
-  # determine default version (if in a package use the package version)
-  default_tutorial_version <- metadata$version
-  if (is.null(default_tutorial_version)) {
-    if (!is.null(package_dir))
-      default_tutorial_version <- package_info$Version
-    else
-      default_tutorial_version <- "1.0"
-  }
+  # determine if we're running inside a package, if so get pkg info
+  pkg <- package_info()
 
   # save the location for later reading
   write_request(session, "tutorial.http_location", location)
 
   # initialize and return identifiers
   list(
-    # tutorial_id
-    tutorial_id = initialize_identifer("tutorial_id",
-                                       default = default_tutorial_id),
-    # tutorial_version
-    tutorial_version = initialize_identifer("tutorial_version",
-                                            default = default_tutorial_version),
-    # user id
-    user_id = initialize_identifer("user_id",
-                                   default = unname(Sys.info()["user"]))
+    tutorial_id = initialize_identifer(
+      "tutorial_id",
+      default = default_tutorial_id(metadata$id, location, pkg)
+    ),
+    tutorial_version = initialize_identifer(
+      "tutorial_version",
+      default = default_tutorial_version(metadata$version, pkg)
+    ),
+    user_id = initialize_identifer("user_id", default = default_user_id())
   )
+}
+
+package_info <- function() {
+  # determine if we are running inside a package
+  package_dir <- tryCatch(
+    rprojroot::find_root(rprojroot::is_r_package, path = getwd()),
+    error = function(e) NULL
+  )
+
+  if (!is.null(package_dir)) {
+    package_desc <- file.path(package_dir, "DESCRIPTION")
+    list(
+      dir = package_dir,
+      desc = package_desc,
+      info = read.dcf(package_desc, all = TRUE)
+    )
+  }
+}
+
+default_tutorial_id <- function(id = NULL, location = NULL, pkg = package_info()) {
+  # determine default tutorial id (metadata first then filesystem-based for
+  # localhost and remote URL based for other configurations)
+  if (!is.null(id)) return(id)
+
+  if (!is_localhost(location)) {
+    return(paste0(location$host, location$pathname))
+  }
+
+  if (is.null(pkg)) {
+    return(getwd())
+  }
+
+  sprintf(
+    "package:%s-%s",
+    pkg$info$Package,
+    sub(paste0("^", pkg$dir), "", getwd())
+  )
+}
+
+default_tutorial_version <- function(version = NULL, pkg = package_info()) {
+  # determine default version (if in a package use the package version)
+  if (!is.null(version)) return(version)
+
+  if (!is.null(pkg$dir)) {
+    return(pkg$info$Version)
+  }
+
+  "1.0"
+}
+
+default_user_id <- function() {
+  unname(Sys.info()["user"])
 }
 
 read_request <- function(session, name, default = NULL) {

--- a/tests/testthat/helpers-exercise.R
+++ b/tests/testthat/helpers-exercise.R
@@ -1,6 +1,6 @@
 mock_exercise <- function(
+  user_code = "1 + 1",
   label = "ex",
-  user_code = "",
   chunks = list(),
   engine = "r",
   global_setup = NULL,
@@ -17,6 +17,7 @@ mock_exercise <- function(
   fig.height = 4,
   fig.width = 6.5,
   fig.retina = 2,
+  version = current_exercise_version,
   ...
 ) {
   default_options <- list(
@@ -61,7 +62,7 @@ mock_exercise <- function(
     ))
   }
 
-  list(
+  ex <- list(
     label = label,
     code = user_code,
     restore = FALSE,
@@ -75,8 +76,19 @@ mock_exercise <- function(
     check = check,
     options = utils::modifyList(default_options, list(...)),
     engine = engine,
-    version = "1"
+    version = version
   )
+
+  if (version == "2") {
+    ex$tutorial <- list(
+      id = "mock_tutorial_id",
+      version = "9.9.9",
+      user_id = "the_learnr"
+    )
+    return(ex)
+  }
+
+  ex
 }
 
 mock_prep_setup <- function(chunks, setup_label) {

--- a/tests/testthat/helpers-exercise.R
+++ b/tests/testthat/helpers-exercise.R
@@ -83,7 +83,8 @@ mock_exercise <- function(
     ex$tutorial <- list(
       id = "mock_tutorial_id",
       version = "9.9.9",
-      user_id = "the_learnr"
+      user_id = "the_learnr",
+      learnr_version = "1.2.3"
     )
     return(ex)
   }

--- a/tests/testthat/helpers-exercise.R
+++ b/tests/testthat/helpers-exercise.R
@@ -79,7 +79,7 @@ mock_exercise <- function(
     version = version
   )
 
-  if (version == "2") {
+  if (!is.null(version) && version == "2") {
     ex$tutorial <- list(
       id = "mock_tutorial_id",
       version = "9.9.9",

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -345,3 +345,19 @@ test_that("filter_dependencies() excludes non-list knit_meta objects", {
     idb_html_dependency()
   )
 })
+
+test_that("exercise versions upgrade correctly", {
+  expect_error(upgrade_exercise(mock_exercise(version = "0")))
+
+  ex_1 <- mock_exercise(version = "1")
+  expect_null(ex_1$tutorial)
+
+  ex_1_upgraded <- upgrade_exercise(ex_1)
+  expect_match(ex_1_upgraded$tutorial$tutorial_id, "UPGRADE")
+  expect_match(ex_1_upgraded$tutorial$tutorial_version, "-1")
+  expect_match(ex_1_upgraded$tutorial$user_id, "UPGRADE")
+
+  ex_2 <- mock_exercise(version = "2")
+  expect_type(ex_2$tutorial, "list")
+  expect_identical(ex_2$tutorial, upgrade_exercise(ex_2)$tutorial)
+})

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -347,7 +347,11 @@ test_that("filter_dependencies() excludes non-list knit_meta objects", {
 })
 
 test_that("exercise versions upgrade correctly", {
+  expect_error(upgrade_exercise(mock_exercise(version = NULL)))
+  expect_error(upgrade_exercise(mock_exercise(version = 1:2)))
+  expect_error(upgrade_exercise(mock_exercise(version = list(a = 1, b = 2))))
   expect_error(upgrade_exercise(mock_exercise(version = "0")))
+  expect_error(upgrade_exercise(mock_exercise(version = "foo")))
 
   ex_1 <- mock_exercise(version = "1")
   expect_null(ex_1$tutorial)
@@ -356,8 +360,32 @@ test_that("exercise versions upgrade correctly", {
   expect_match(ex_1_upgraded$tutorial$tutorial_id, "UPGRADE")
   expect_match(ex_1_upgraded$tutorial$tutorial_version, "-1")
   expect_match(ex_1_upgraded$tutorial$user_id, "UPGRADE")
+  expect_equal(paste(ex_1_upgraded$version), "2")
 
   ex_2 <- mock_exercise(version = "2")
   expect_type(ex_2$tutorial, "list")
   expect_identical(ex_2$tutorial, upgrade_exercise(ex_2)$tutorial)
+
+  # future versions
+  ex_99 <- mock_exercise(version = 99)
+  expect_equal(
+    expect_warning(upgrade_exercise(ex_99)),
+    ex_99
+  )
+
+  # broken but okay future version
+  ex_99_broken <- ex_99
+  ex_99_broken$global_setup <- NULL
+  expect_equal(
+    expect_warning(upgrade_exercise(ex_99_broken)),
+    ex_99_broken
+  )
+
+  # broken but not okay
+  expect_error(upgrade_exercise(ex_99_broken, require_items = "global_setup"))
+
+  # broken in other non-optional ways
+  # (this version of learnr makes a strong assumption that "label" is part of exercise)
+  ex_99_broken$label <- NULL
+  expect_error(upgrade_exercise(ex_99_broken))
 })


### PR DESCRIPTION
This PR adds a `tutorial` item to the `exercise` object with `tutorial_id`, `tutorial_version` and `user_id` (although `user_id` is scrubbed if the exercise is sent to an external evaluator). These values are added by the learnr shiny app and aren't cached as they can change at run time: https://rstudio.github.io/learnr/publishing.html#Recording_Events.

The goal is to make critical tutorial information available to the external evaluator or to exercise checking code. The motivating case is to access data hosted at a path that is constructed from the tutorial id.

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
