### PR TITLE
fix: Relocate tabset init in tutorial pandoc template

### DIFF
--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -102,18 +102,6 @@ $endif$
   display: none;
 }
 </style>
-
-<script>
-$$(document).ready(function () {
-  window.buildTabsets("$idprefix$TOC");
-});
-
-$$(document).ready(function () {
-  $$('.tabset-dropdown > .nav-tabs > li').click(function () {
-    $$(this).parent().toggleClass('nav-tabs-open')
-  });
-});
-</script>
 <!-- end tabsets -->
 
 $if(highlighting-css)$
@@ -205,6 +193,18 @@ $for(include-after)$
 $include-after$
 $endfor$
 
+<!-- Build Tabsets -->
+<script>
+$$(document).ready(function () {
+  window.buildTabsets("$idprefix$TOC");
+});
+
+$$(document).ready(function () {
+  $$('.tabset-dropdown > .nav-tabs > li').click(function () {
+    $$(this).parent().toggleClass('nav-tabs-open')
+  });
+});
+</script>
 
 <script>
 // add bootstrap table styles to pandoc tables


### PR DESCRIPTION
Fixes #499

Moved tabset initialization to later in the tutorial template to ensure that jquery is loaded before it is used to setup tabsets.