### PR TITLE
exercise$tutorial$learnr_version must be character

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -24,7 +24,7 @@ setup_exercise_handler <- function(exercise_rx, session) {
       tutorial_id = read_request(session, "tutorial.tutorial_id"),
       tutorial_version = read_request(session, "tutorial.tutorial_version"),
       user_id = read_request(session, "tutorial.user_id"),
-      learnr_version = utils::packageVersion("learnr")
+      learnr_version = as.character(utils::packageVersion("learnr"))
     )
 
     # short circuit for restore (we restore some outputs like errors so that

--- a/tests/testthat/helpers-exercise.R
+++ b/tests/testthat/helpers-exercise.R
@@ -84,7 +84,7 @@ mock_exercise <- function(
       id = "mock_tutorial_id",
       version = "9.9.9",
       user_id = "the_learnr",
-      learnr_version = "1.2.3"
+      learnr_version = as.character(utils::packageVersion("learnr"))
     )
     return(ex)
   }


### PR DESCRIPTION
so that exercise objects round-trip through JSON correctly.

```
jsonlite::toJSON(list(learnr_version = packageVersion("learnr")))
#> Error: No method asJSON S3 class: numeric_version
```