### PR TITLE
Adds "quick restore" option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ learnr (development version)
 * Added Portuguese language support (@beatrizmilz [#488](https://github.com/rstudio/learnr/pull/488))
 * Added Basque language support (@mikelmadina [#489](https://github.com/rstudio/learnr/pull/489))
 * Added Turkish language support (@hyigit2, @coatless [#493](https://github.com/rstudio/learnr/pull/493))
+* Added option for quickly restoring a tutorial without re-evaluating the last stored exercise submission. This feature is enabled by setting the global option `tutorial.quick_restore = TRUE` or the environment variable `TUTORIAL_QUICK_RESTORE=1` (thanks @mstackhouse, [#509](https://github.com/rstudio/learnr/pull/509)).
 
 
 ## Bug fixes

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -30,6 +30,17 @@ setup_exercise_handler <- function(exercise_rx, session) {
     # short circuit for restore (we restore some outputs like errors so that
     # they are not re-executed when bringing the tutorial back up)
     if (exercise$restore) {
+      if (
+        getOption(
+          "tutorial.quick_restore",
+          identical(Sys.getenv("TUTORIAL_QUICK_RESTORE", "0"), "1")
+        )
+      ) {
+        # don't evaluate at all if quick_restore is enabled
+        rv$result <- list()
+        return()
+      }
+
       object <- get_exercise_submission(session = session, label = exercise$label)
       if (!is.null(object) && !is.null(object$data$output)) {
 


### PR DESCRIPTION
I added a `tutorial.quick_restore` global option, that falls back to the env variable `TUTORIAL_QUICK_RESTORE`. (I'm totally open to re-naming this feature or option, btw.) When `TRUE` or `1`, submitted user code is not evaluated on the server. This will be helpful for large tutorials with many exercises; the user code is restored but the output is not evaluated.

Currently, no message or feedback is shown, so users will need to click on _Run Code_ or _Submit Answer_ to see the output in the re-loaded tutorial. I don't think this will surprise anyone. I chose not to add a message because it's not clear to me where the internationalization aspect would live for that message and the benefit to customizing or showing the message is small.

Fixes #508
