### PR TITLE
Run selected text if available instead of complete exercise code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@ learnr (development version)
 * Added Basque language support (@mikelmadina [#489](https://github.com/rstudio/learnr/pull/489))
 * Added Turkish language support (@hyigit2, @coatless [#493](https://github.com/rstudio/learnr/pull/493))
 * Added option for quickly restoring a tutorial without re-evaluating the last stored exercise submission. This feature is enabled by setting the global option `tutorial.quick_restore = TRUE` or the environment variable `TUTORIAL_QUICK_RESTORE=1` (thanks @mstackhouse, [#509](https://github.com/rstudio/learnr/pull/509)).
+* Clicking "Run Code" or using the keyboard shortcut (Cmd/Ctrl + Enter) now runs the selected code only, if any code is selected ([#512](https://github.com/rstudio/learnr/issues/512)).
 
 
 ## Bug fixes

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1366,7 +1366,7 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
 
       // get the code from the editor
       var editor = ace.edit($(el).attr('id'));
-      value.code = editor.getSession().getValue();
+      value.code = editor.getSelectedText() || editor.getSession().getValue();
 
       // restore flag
       value.restore = this.restore;

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1364,14 +1364,17 @@ Tutorial.prototype.$initializeExerciseEvaluation = function() {
       // get the label
       value.label = exerciseLabel(el);
 
+      // running code or submitting an answer for checking?
+      value.should_check = this.should_check;
+
       // get the code from the editor
       var editor = ace.edit($(el).attr('id'));
-      value.code = editor.getSelectedText() || editor.getSession().getValue();
+      value.code = value.should_check
+        ? editor.getSession().getValue()
+        : editor.getSelectedText() || editor.getSession().getValue();
 
       // restore flag
       value.restore = this.restore;
-
-      value.should_check = this.should_check;
 
       // some randomness to ensure we re-execute on button clicks
       value.timestamp = new Date().getTime();


### PR DESCRIPTION
Fixes #512. 

A note about implementation: I used `editor.getSelectedText()` to get the selected text in the editor. We're currently using `editor.getSession().getValue()` for the full code in the editor. I'm fairly certain that `editor.getSession()` is not required — I think `editor.getValue()` will return the same thing — and if it is required then we would need to follow a much more complicated way of getting the selected text.

TODO:

- [ ] NEWS item

