### PR TITLE
Change default value of radio button to avoid selecting "FALSE" option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@ learnr (development version)
 * When a quiz's question or answer text are not characters, e.g. HTML, `htmltools` tags, numeric, etc., they are now cast to characters for the displayed answer text and the quiz's default loading text ([#450](https://github.com/rstudio/learnr/pull/450)).
 * The `envir_prep` environment used in exercise checking now captures the result of both global and exercise-specific setup code, representing the environment in which the user code will be evaluated as described in the documentation. We also ensure that `envir_result` (the environment containing the result of evaluating global, setup and user code) is a sibling of `envir_prep`. ([#480](https://github.com/rstudio/learnr/pull/480))
 * HTML dependencies of exercises run by users now excludes dependencies created with `htmltools::tags$head()`. (thanks @andysouth, [#484](https://github.com/rstudio/learnr/issues/484))
+* Avoid selecting the answer labeled `"FALSE"` by default in `question_radio()` ([#515](https://github.com/rstudio/learnr/pull/515)).
 
 learnr 0.10.1
 ===========

--- a/R/question_radio.R
+++ b/R/question_radio.R
@@ -53,7 +53,7 @@ question_ui_initialize.learnr_radio <- function(question, value, ...) {
     label = question$question,
     choiceNames = choice_names,
     choiceValues = choice_values,
-    selected = value %||% NA # setting to NULL, selects the first item
+    selected = value %||% NA # avoid selecting the first item when value is NULL
   )
 }
 

--- a/R/question_radio.R
+++ b/R/question_radio.R
@@ -53,7 +53,7 @@ question_ui_initialize.learnr_radio <- function(question, value, ...) {
     label = question$question,
     choiceNames = choice_names,
     choiceValues = choice_values,
-    selected = value %||% NA # avoid selecting the first item when value is NULL
+    selected = value %||% character(0) # avoid selecting the first item when value is NULL
   )
 }
 

--- a/R/question_radio.R
+++ b/R/question_radio.R
@@ -53,7 +53,7 @@ question_ui_initialize.learnr_radio <- function(question, value, ...) {
     label = question$question,
     choiceNames = choice_names,
     choiceValues = choice_values,
-    selected = value %||% FALSE # setting to NULL, selects the first item
+    selected = value %||% NA # setting to NULL, selects the first item
   )
 }
 


### PR DESCRIPTION
Reported: https://community.rstudio.com/t/avoid-pre-selected-answers-in-learnr-multiple-choice-questions/101950

Previously, when the answer label was `"FALSE"`, that value would be selected because the default value of `selected` in `radioButtons()` was `FALSE`.

````
```{r KC-1, echo=FALSE}
question("TRUE or FALSE: My R Scripts can look sloppy as long as RStudio is able to run it.",
  answer("TRUE", message = "Not quite. Think about all the *computers* you are creating computer programs for."),
  answer("FALSE", correct = TRUE, message = "That's right. You should strive to make your computer programs should be interpretable by other humans as well."),
  allow_retry = FALSE
)
```
````

![image](https://user-images.githubusercontent.com/5420529/114902545-ed577180-9de3-11eb-91e6-64f5755e9a91.png)
