### PR TITLE
Separate feedback html from code output html in `exercise_result()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: learnr
 Title: Interactive Tutorials for R
-Version: 0.10.1.9008
+Version: 0.10.1.9009
 Authors@R: 
     c(person(given = "Barret",
              family = "Schloerke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,7 +43,7 @@ learnr (development version)
 * Added Turkish language support (@hyigit2, @coatless [#493](https://github.com/rstudio/learnr/pull/493))
 * Added option for quickly restoring a tutorial without re-evaluating the last stored exercise submission. This feature is enabled by setting the global option `tutorial.quick_restore = TRUE` or the environment variable `TUTORIAL_QUICK_RESTORE=1` (thanks @mstackhouse, [#509](https://github.com/rstudio/learnr/pull/509)).
 * Clicking "Run Code" or using the keyboard shortcut (Cmd/Ctrl + Enter) now runs the selected code only, if any code is selected ([#512](https://github.com/rstudio/learnr/issues/512)).
-
+* `exercise_result()` no longer combines the code output and feedback; this now happens just before presenting the exercise result to the user ([#522](https://github.com/rstudio/learnr/pull/522)).
 
 ## Bug fixes
 


### PR DESCRIPTION
Fixes #520

This separates the exercise result object from the final HTML form returned into the learnr tutorial. I extracted the logic that concatenates the `feedback_html` and the `html_output` into a new function `exercise_result_as_html()`. The feedback is still rendered into HTML when we create the exercise result object, but we instead store it separately as `$feedback$html`.

This decouples the exercise evaluation from its final presentation.

```r
ex <- mock_exercise(
  user_code = "1 + 3",
  solution_code = "1 + 1",
  check = "gradethis::grade_this({
    gradethis::pass_if_equal(2)
    gradethis::fail()
  })",
  exercise.checker = "gradethis::gradethis_exercise_checker"
)

result <- evaluate_exercise(ex, new.env())

result # shown as yaml
```

```yaml
feedback:
  message: |
    <p>Incorrect. In <code>1 + 3</code>, I expected <code>1</code> where you wrote <code>3</code>. Don’t give up now, try it one more time.</p>
  correct: no
  type: error
  location: append
  html:
    name: div
    attribs:
      role: alert
      class: alert alert-danger
    children:
    - |
      <p>Incorrect. In <code>1 + 3</code>, I expected <code>1</code> where you wrote <code>3</code>. Don’t give up now, try it one more time.</p>
error_message: ~
timeout_exceeded: no
html_output: |2-
  <pre><code>[1] 4</code></pre>
```

In a learnr tutorial, the exercise result is turned into HTML before presenting to the user. This now happens inside the shiny learnr logic rather than when the exercise result is created.

```r
exercise_result_as_html(result)
```

```
<pre><code>[1] 4</code></pre>
<div role="alert" class="alert alert-danger"><p>Incorrect. In <code>1 + 3</code>, I expected <code>1</code> where you wrote <code>3</code>. Don’t give up now, try it one more time.</p>
</div>
```