### PR TITLE
Update testing os/version matrix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-16.04, r: 'release', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-18.04, r: 'devel', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}
           - {os: ubuntu-18.04, r: 'release', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04, r: '4.0', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}
           - {os: ubuntu-18.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}
           - {os: ubuntu-18.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}
           - {os: ubuntu-18.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/bionic/latest"}


### PR DESCRIPTION
Drops testing on windows devel, moves full matrix of testing from 3.3 to devel to ubuntu-18.04.

|version |date                |nickname               |
|:-------|:-------------------|:----------------------|
|4.1.0   |2021-05-18 07:05:22 |Camp Pontanezen        |
|4.0.0   |2020-04-24 07:05:34 |Arbor Day              |
|3.6.0   |2019-04-26 07:05:03 |Planting of a Tree     |
|3.5.0   |2018-04-23 07:04:38 |Joy in Playing         |
|3.4.0   |2017-04-21 07:14:45 |You Stupid Darkness    |
|3.3.0   |2016-05-03 07:13:28 |Supposedly Educational |
