### PR TITLE
Support bs4+ popover `'dispose'` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ learnr (development version)
 
 ## Bug fixes
 
+* Support the updated Bootstrap 4+ popover `dispose` method name, previously `destroy`. ([#560](https://github.com/rstudio/learnr/pull/560))
 * Properly enforce time limits and measure exercise execution times that exceed 60 seconds ([#366](https://github.com/rstudio/learnr/pull/366), [#368](https://github.com/rstudio/learnr/pull/368))
 * Fixed unexpected behavior for `question_is_correct.learnr_text()` where `trim = FALSE`. Comparisons will now happen with the original input value, not the `HTML()` formatted answer value. ([#376](https://github.com/rstudio/learnr/pull/376))
 * Fixed exercise progress spinner being prematurely cleared. ([#384](https://github.com/rstudio/learnr/pull/384))

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1319,7 +1319,8 @@ Tutorial.prototype.$removeSolution = function(exercise) {
     solutionButton.data('clipboard').destroy();
 
   // destroy popover
-  exercise.find('.btn-tutorial-solution').popover('destroy');
+  // If window.bootstrap is found (>= bs4), use `'dispose'` method name. Otherwise, use `'destroy'` (bs3)
+  exercise.find('.btn-tutorial-solution').popover(window.bootstrap ? 'dispose' : 'destroy');
 };
 
 


### PR DESCRIPTION
Correct issue in comment: https://github.com/rstudio/learnr/issues/468#issuecomment-887617871

PR task list:
- [x] Update NEWS
- [NA] Add tests (if possible)
- [NA] Update documentation with `devtools::document()`
