### PR TITLE
Use entropy method to detect and redact API keys in exercise output

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1026,7 +1026,10 @@ output_redact_secrets <- function(path) {
     vapply(words, word_entropy, numeric(1))
   }
 
-  lines <- readLines(path, warn = FALSE)
+  lines <- path
+  if (length(path) == 1) {
+    lines <- readLines(path, warn = FALSE)
+  }
 
   for (i in seq_along(lines)) {
     line_entropy <- line_words_entropy(lines[i])
@@ -1039,7 +1042,10 @@ output_redact_secrets <- function(path) {
     }
   }
 
-  writeLines(lines, path)
-
-  invisible(lines)
+  if (length(path) == 1) {
+    writeLines(lines, path)
+    invisible(lines)
+  } else {
+    lines
+  }
 }

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -590,18 +590,17 @@ render_exercise <- function(exercise, envir) {
     # Disable shiny domain
     shiny::withReactiveDomain(NULL, {
       # Disable connect api keys and connect server info
-      withr::local_envvar(list(CONNECT_API_KEY = "", CONNECT_SERVER = ""))
-
-      # Now render user code for final result
-      rmarkdown::render(
-        input = rmd_file_user,
-        output_format = output_format_exercise(user = TRUE),
-        envir = envir_result,
-        clean = FALSE,
-        quiet = TRUE,
-        run_pandoc = FALSE
-      )
-
+      withr::with_envvar(list(CONNECT_API_KEY = "", CONNECT_SERVER = ""), {
+        # Now render user code for final result
+        rmarkdown::render(
+          input = rmd_file_user,
+          output_format = output_format_exercise(user = TRUE),
+          envir = envir_result,
+          clean = FALSE,
+          quiet = TRUE,
+          run_pandoc = FALSE
+        )
+      })
     })
 
   }, error = function(e) {

--- a/R/options.R
+++ b/R/options.R
@@ -20,6 +20,8 @@
 #' @param exercise.startover Show "Start Over" button on exercise.
 #' @param exercise.reveal_solution Whether to reveal the exercise solution if
 #'   a solution chunk is provided.
+#' @param exercise.redact_potential_secrets Whether to hide potential secrets if
+#'   a user attempts to print them in an interactive exercise.
 #'
 #' @export
 tutorial_options <- function(exercise.cap = NULL,
@@ -31,9 +33,10 @@ tutorial_options <- function(exercise.cap = NULL,
                              exercise.completion = TRUE,
                              exercise.diagnostics = TRUE,
                              exercise.startover = TRUE,
-                             exercise.reveal_solution = TRUE)
+                             exercise.reveal_solution = TRUE,
+                             exercise.redact_potential_secrets = NULL)
 {
-  # string to evalute for setting chunk options  %1$s
+  # string to evaluate for setting chunk options  %1$s
   set_option_code <- 'if (!missing(%1$s)) knitr::opts_chunk$set(%1$s = %1$s)'
 
   # set options as required
@@ -47,4 +50,5 @@ tutorial_options <- function(exercise.cap = NULL,
   eval(parse(text = sprintf(set_option_code, "exercise.diagnostics")))
   eval(parse(text = sprintf(set_option_code, "exercise.startover")))
   eval(parse(text = sprintf(set_option_code, "exercise.reveal_solution")))
+  eval(parse(text = sprintf(set_option_code, "exercise.redact_potential_secrets")))
 }

--- a/man/tutorial_options.Rd
+++ b/man/tutorial_options.Rd
@@ -14,7 +14,8 @@ tutorial_options(
   exercise.completion = TRUE,
   exercise.diagnostics = TRUE,
   exercise.startover = TRUE,
-  exercise.reveal_solution = TRUE
+  exercise.reveal_solution = TRUE,
+  exercise.redact_potential_secrets = NULL
 )
 }
 \arguments{
@@ -43,6 +44,9 @@ code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_cod
 
 \item{exercise.reveal_solution}{Whether to reveal the exercise solution if
 a solution chunk is provided.}
+
+\item{exercise.redact_potential_secrets}{Whether to hide potential secrets if
+a user attempts to print them in an interactive exercise.}
 }
 \description{
 Set various tutorial options that control the display and evaluation of

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -831,3 +831,25 @@ test_that("Shiny session is diabled", {
   expect_match(res$html_output, "<code>NULL</code>", fixed = TRUE)
 
 })
+
+
+# Redacting keys from output ----------------------------------------------
+
+test_that("Keys are redacted from exercise output", {
+  keys <- c(
+    "oVHzQgQvNaod5Qbchog3m6sicGEZaM",
+    "C4gnKRtbk7rIHpkftrM4kqvEjQTdwZnnfAoM0p",
+    "De5Zsa05m4XsiGGhdAwyGas450ufICU5",
+    "iX4GtPZKp7ZWx3Cg8Ch",
+    "ghp_383a3dfb8efa9f0eab8bc50a6a024e477616"
+  )
+
+  for (key in keys) {
+    text <- paste0("foo\nthis is my key ", key, "\nbar")
+    text_expected <- paste0('<pre><code>foo\nthis is my key ', substr(key, 1, 5), "...\nbar</code></pre>\n")
+    expect_equal(
+      output_hook_redact_secrets(text, list(engine = "r")),
+      text_expected
+    )
+  }
+})

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -845,10 +845,13 @@ test_that("Keys are redacted from exercise output", {
   )
 
   for (key in keys) {
-    text <- paste0("foo\nthis is my key ", key, "\nbar")
-    text_expected <- paste0('<pre><code>foo\nthis is my key ', substr(key, 1, 5), "...\nbar</code></pre>\n")
+    text <- c("foo", paste0("this is my key ", key), "bar")
+    tmpfile <- withr::local_tempfile()
+    writeLines(text, tmpfile)
+
+    text_expected <- c("foo", paste0("this is my key ", substr(key, 1, 5), "...redacted..."), "bar")
     expect_equal(
-      output_hook_redact_secrets(text, list(engine = "r")),
+      output_redact_secrets(tmpfile),
       text_expected
     )
   }


### PR DESCRIPTION
This PR follows up on the protections provided in #563 by scrubbing potentially sensitive strings from the exercise output.

The methods used are derived from [auth0/repo-supervisor](https://github.com/auth0/repo-supervisor) and [trufflesecurity/trufleHog](https://github.com/trufflesecurity/truffleHog) to identify and redact long (13-character) strings with high entropy (4+).

In comparison with the approach I first propsed in #563, this PR doesn't use knitr hooks and instead redacts the intermediate markdown file prior to the markdown to HTML conversion.

```r
# user submits
Sys.getenv("GITHUB_PAT")
```

<pre><code>[1] &quot;ghp_3...redacted...&quot;</code></pre>

<details><summary>reprex</summary>

```r
ex_result <- withr::with_envvar(
  list(GITHUB_PAT = "ghp_383a3dfb8efa9f0eab8bc50a6a024e477616"), {
    ex <- mock_exercise('Sys.getenv("GITHUB_PAT")')
    withr::with_tempdir(
      render_exercise(ex, new.env())
    )
  }
)

ex_result$html_output
```

</details>

