### PR TITLE
Transition remote dependencies to CRAN releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,8 +78,6 @@ Suggests:
     testthat (>= 2.1.0)
 VignetteBuilder:
     knitr
-Remotes:
-    rstudio/htmltools
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,13 +74,12 @@ Suggests:
     callr,
     httpuv,
     later,
-    shinytest (>= 1.4.0.9002),
+    shinytest (>= 1.5.0),
     testthat (>= 2.1.0)
 VignetteBuilder:
     knitr
 Remotes:
-    rstudio/htmltools,
-    rstudio/shinytest
+    rstudio/htmltools
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
- `shinytest` 1.5.0 is available on CRAN (and is latest released version after 1.4.0.9002)
- `htmltools` 0.3.5 was released to CRAN a while ago (current CRAN version is 0.5.1.1)