### PR TITLE
Include custom CSS after learnr html dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,7 @@ learnr (development version)
 * The `envir_prep` environment used in exercise checking now captures the result of both global and exercise-specific setup code, representing the environment in which the user code will be evaluated as described in the documentation. We also ensure that `envir_result` (the environment containing the result of evaluating global, setup and user code) is a sibling of `envir_prep`. ([#480](https://github.com/rstudio/learnr/pull/480))
 * HTML dependencies of exercises run by users now excludes dependencies created with `htmltools::tags$head()`. (thanks @andysouth, [#484](https://github.com/rstudio/learnr/issues/484))
 * Avoid selecting the answer labeled `"FALSE"` by default in `question_radio()` ([#515](https://github.com/rstudio/learnr/pull/515)).
+* Custom CSS files are now loaded last, after all of learnr's other web dependencies. ([#574](https://github.com/rstudio/learnr/pull/574))
 
 learnr 0.10.1
 ===========

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -118,6 +118,8 @@ $if(theme)$
 $endif$
 $endif$
 
+<!-- HEAD_CONTENT -->
+
 $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
 $endfor$


### PR DESCRIPTION
Due to the changes in rstudio/rmarkdown#2064, the HTML dependencies for learnr tutorials are now being added just before the closing `<head>` tag. This is generally a good thing, but these dependencies are inserted between custom CSS links and the closing head tag, causing the default CSS rules to be applied _over_ the custom rules rather than the other way around.

This PR uses the new `<!-- HEAD_CONTENT -->` placeholder to ensure that the default dependencies appear _before_ customm CSS.

Originally reported on RStudio Community: [learnr style appears to be broken on re-publish - shiny - RStudio Community](https://community.rstudio.com/t/learnr-style-appears-to-be-broken-on-re-publish/113435)
