### PR TITLE
`get_tutorial_info()` can extract metadata from a tutorial's source file

### DIFF
--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -214,7 +214,10 @@ get_tutorial_info <- function(session = getDefaultReactiveDomain(), tutorial_pat
     if (!is.null(rmd_meta) && length(rmd_meta)) {
       rmd_meta
     } else if (!is.null(tutorial_path)) {
-      rmarkdown::yaml_front_matter(tutorial_path, ...)
+      tryCatch(
+        rmarkdown::yaml_front_matter(tutorial_path, ...),
+        error = function(e) NULL
+      )
     }
 
   tutorial_language <-

--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -204,9 +204,10 @@ get_tutorial_info <- function(session = getDefaultReactiveDomain(), tutorial_pat
 
   if (!is.null(session) && !is.null(tutorial_path)) {
     warning(
-      "Calling `get_tutorial_info()` with the `tutorial_path` argument inside ",
-      "a Shiny reactive domain may mask the metadata of the currently running tutorial."
+      "The `tutorial_path` argument is ignored when `get_tutorial_info()` is ",
+      "called inside a Shiny reactive domain."
     )
+    tutorial_path <- NULL
   }
 
   rmd_meta <- rmarkdown::metadata

--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -330,6 +330,6 @@ prepare_tutorial_cache_from_source <- function(path_rmd) {
     }
   )
 
-  get_tutorial_info(tutorial_path = path_rmd)
+  get_tutorial_info(NULL, tutorial_path = path_rmd)
 }
 

--- a/man/get_tutorial_info.Rd
+++ b/man/get_tutorial_info.Rd
@@ -4,11 +4,24 @@
 \alias{get_tutorial_info}
 \title{Get information about the current tutorial}
 \usage{
-get_tutorial_info(session = getDefaultReactiveDomain())
+get_tutorial_info(
+  session = getDefaultReactiveDomain(),
+  tutorial_path = NULL,
+  ...
+)
 }
 \arguments{
 \item{session}{The \code{session} object passed to function given to
 \code{shinyServer.} Default is \code{\link[shiny:domains]{shiny::getDefaultReactiveDomain()}}.}
+
+\item{tutorial_path}{Path to a tutorial \code{.Rmd} source file}
+
+\item{...}{
+  Arguments passed on to \code{\link[rmarkdown:yaml_front_matter]{rmarkdown::yaml_front_matter}}
+  \describe{
+    \item{\code{input}}{Input file (Rmd or plain markdown)}
+    \item{\code{encoding}}{Ignored. The encoding is always assumed to be UTF-8.}
+  }}
 }
 \value{
 Returns an ordinary list with the following elements:

--- a/tests/testthat/test-tutorial-state.R
+++ b/tests/testthat/test-tutorial-state.R
@@ -19,10 +19,18 @@ test_that("store works", {
 
 
 test_that("tutorial_cache_works", {
-  prepare_tutorial_cache_from_source(test_path("tutorials", "basic.Rmd"))
+  info <- prepare_tutorial_cache_from_source(test_path("tutorials", "basic.Rmd"))
   withr::defer(clear_tutorial_cache())
 
+  # prepare_tutorial_cache() returns get_tutorial_info()
+  expect_equal(info$tutorial_id, "test-basic")
+  expect_equal(info$tutorial_version, "9.9.9")
+  expect_s3_class(info$items, "data.frame")
+  expect_named(info$items, c("order", "label", "type", "data"))
+
   all <- get_tutorial_cache()
+  expect_equal(info$items$data, unname(all))
+
   # tutorial cache lists items in order of appearance
   exercises <- c("two-plus-two", "add-function", "print-limit")
   questions <- c("quiz-1", "quiz-2")

--- a/tests/testthat/tutorials/basic.Rmd
+++ b/tests/testthat/tutorials/basic.Rmd
@@ -1,6 +1,9 @@
 ---
 title: "Tutorial"
 output: learnr::tutorial
+tutorial:
+  id: test-basic
+  version: 9.9.9
 runtime: shiny_prerendered
 ---
 


### PR DESCRIPTION
This PR adds `tutorial_path` to `get_tutorial_info()`, which then attempts to extract the tutorial id, version and language from the source file. The information is now reported in this order:

1. Using `tutorial_path` by extracting/working with the front matter -- available only in interactive console.
2. During render using `rmarkdown::metadata` with the version of the front matter used by rmarkdown -- available only during pre-render step
3. During the running tutorial using the `session` object -- available only inside running Shiny app

I also updated some internal functions to take advantage of this new argument.