### PR TITLE
Use `feedback$html` if present or reconstruct otherwise

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: learnr
 Title: Interactive Tutorials for R
-Version: 0.10.1.9014
+Version: 0.10.1.9015
 Authors@R:
     c(person(given = "Barret",
              family = "Schloerke",

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -864,7 +864,9 @@ exercise_result <- function(
 ) {
   feedback <- feedback_validated(feedback)
 
-  if (!is.null(feedback)) {
+  if (is.character(feedback$html) && any(nzchar(feedback$html))) {
+    feedback$html <- htmltools::HTML(feedback$html)
+  } else if (!inherits(feedback$html, c("shiny.tag", "shiny.tag.list", "html"))) {
     feedback$html <- feedback_as_html(feedback)
   }
 


### PR DESCRIPTION
If it's character, assume it should be HTML and mark it as html. Otherwise if not htmltools tag or tag list, reconstruct the feedback html.

Primarily, this affects external evaluators that include `feedback$html` pre-filled but that have passed through a JSON serialization that removes the attributes and classes that mark the item as HTML. In short, external evaluators should return a character strings of HTML for pre-constructed `feedback$html`, otherwise leave the item empty (`NULL`) for it to be reconstructed by the primary tutorial app.