### PR TITLE
Include a default English message for blank/unparsable errors `i18n_span()`

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -802,31 +802,30 @@ exercise_check_code_for_blanks <- function(exercise) {
   # default message is stored in data-raw/i18n_translations.yml
   text <- i18n_translations()$en$translation$text
 
+  text_blanks <- gsub(
+    "$t(text.blank)",
+    ngettext(length(blanks), "blank", "blanks"),
+    text$exercisecontainsblank,
+    fixed = TRUE
+  )
+  text_blanks <- gsub("{{count}}", length(blanks), text_blanks, fixed = TRUE)
+
+  text_please <- gsub(
+    "{{blank}}",
+    knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
+    text$pleasereplaceblank,
+    fixed = TRUE
+  )
+
   msg <- paste(
     i18n_span(
-      "text.exercisecontainsblank",
-      gsub(
-        "{{count}}", length(blanks),
-        gsub(
-          "$t(text.blank)", ngettext(length(blanks), "blank", "blanks"),
-          text$exercisecontainsblank,
-          fixed = TRUE
-        ),
-        i18n_translations()$en$translation$text$exercisecontainsblank,
-        fixed = TRUE
-      ),
+      HTML(text_blanks),
+      key = "text.exercisecontainsblank",
       opts = list(count = length(blanks))
     ),
     i18n_span(
-      "text.pleasereplaceblank",
-      HTML(
-        gsub(
-          "{{blank}}",
-          knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
-          text$pleasereplaceblank,
-          fixed = TRUE
-        )
-      ),
+      HTML(text_please),
+      key = "text.pleasereplaceblank",
       opts = list(
         count = length(blanks),
         blank = i18n_combine_words(unique(blanks), before = "<code>", after = "</code>"),

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -800,12 +800,12 @@ exercise_check_code_for_blanks <- function(exercise) {
   }
 
   # default message is stored in data-raw/i18n_translations.yml
-  text <- i18n_translations()$en$translation$text
+  i18n_text <- i18n_translations()$en$translation$text
 
   text_blanks <- gsub(
     "$t(text.blank)",
     ngettext(length(blanks), "blank", "blanks"),
-    text$exercisecontainsblank,
+    i18n_text$exercisecontainsblank,
     fixed = TRUE
   )
   text_blanks <- gsub("{{count}}", length(blanks), text_blanks, fixed = TRUE)
@@ -813,7 +813,7 @@ exercise_check_code_for_blanks <- function(exercise) {
   text_please <- gsub(
     "{{blank}}",
     knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
-    text$pleasereplaceblank,
+    i18n_text$pleasereplaceblank,
     fixed = TRUE
   )
 

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -799,6 +799,8 @@ exercise_check_code_for_blanks <- function(exercise) {
     return(NULL)
   }
 
+  text <- i18n_translations()$en$translation$text
+
   msg <- paste(
     i18n_span(
       "text.exercisecontainsblank",
@@ -806,7 +808,7 @@ exercise_check_code_for_blanks <- function(exercise) {
         "{{count}}", length(blanks),
         gsub(
           "$t(text.blank)", ngettext(length(blanks), "blank", "blanks"),
-          i18n_translations()$en$translation$text$exercisecontainsblank,
+          text$exercisecontainsblank,
           fixed = TRUE
         ),
         i18n_translations()$en$translation$text$exercisecontainsblank,
@@ -820,7 +822,7 @@ exercise_check_code_for_blanks <- function(exercise) {
         gsub(
           "{{blank}}",
           knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
-          i18n_translations()$en$translation$text$pleasereplaceblank,
+          text$pleasereplaceblank,
           fixed = TRUE
         )
       ),

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -802,19 +802,26 @@ exercise_check_code_for_blanks <- function(exercise) {
   msg <- paste(
     i18n_span(
       "text.exercisecontainsblank",
-      paste0(
-        "This exercise contains ", length(blanks),
-        ngettext(length(blanks), " blank.", " blanks.")
+      gsub(
+        "{{count}}", length(blanks),
+        gsub(
+          "$t(text.blank)", ngettext(length(blanks), "blank", "blanks"),
+          i18n_translations()$en$translation$text$exercisecontainsblank,
+          fixed = TRUE
+        ),
+        i18n_translations()$en$translation$text$exercisecontainsblank,
+        fixed = TRUE
       ),
       opts = list(count = length(blanks))
     ),
     i18n_span(
       "text.pleasereplaceblank",
       HTML(
-        paste(
-          "Please replace",
+        gsub(
+          "{{blank}}",
           knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
-          "with valid code."
+          i18n_translations()$en$translation$text$pleasereplaceblank,
+          fixed = TRUE
         )
       ),
       opts = list(

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -802,10 +802,21 @@ exercise_check_code_for_blanks <- function(exercise) {
   msg <- paste(
     i18n_span(
       "text.exercisecontainsblank",
+      paste0(
+        "This exercise contains ", length(blanks),
+        ngettext(length(blanks), " blank.", " blanks.")
+      ),
       opts = list(count = length(blanks))
     ),
     i18n_span(
       "text.pleasereplaceblank",
+      HTML(
+        paste(
+          "Please replace",
+          knitr::combine_words(unique(blanks), before = "<code>", after = "</code>"),
+          "with valid code."
+        )
+      ),
       opts = list(
         count = length(blanks),
         blank = i18n_combine_words(unique(blanks), before = "<code>", after = "</code>"),
@@ -827,7 +838,12 @@ exercise_check_code_is_parsable <- function(exercise) {
 
   exercise_result(
     list(
-      message = HTML(i18n_span("text.unparsable")),
+      message = HTML(
+        i18n_span(
+          "text.unparsable",
+          HTML(i18n_translations()$en$translation$text$unparsable)
+        )
+      ),
       correct = FALSE,
       location = "append",
       type = "error"

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -799,6 +799,7 @@ exercise_check_code_for_blanks <- function(exercise) {
     return(NULL)
   }
 
+  # default message is stored in data-raw/i18n_translations.yml
   text <- i18n_translations()$en$translation$text
 
   msg <- paste(

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -792,17 +792,22 @@ test_that("evaluate_exercise() returns a message if code contains ___", {
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:1")
-  expect_match(result$feedback$message, "____")
+  expect_match(result$feedback$message, "This exercise contains 1 blank.")
+  expect_match(result$feedback$message, "Please replace <code>____</code> with valid code.")
 
   ex     <- mock_exercise(user_code = '____(____)')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:2")
+  expect_match(result$feedback$message, "This exercise contains 2 blanks.")
+  expect_match(result$feedback$message, "Please replace <code>____</code> with valid code.")
 
   ex     <- mock_exercise(user_code = '____("____")')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:2")
+  expect_match(result$feedback$message, "This exercise contains 2 blanks.")
+  expect_match(result$feedback$message, "Please replace <code>____</code> with valid code.")
 })
 
 test_that("setting a different blank for the blank checker", {
@@ -810,17 +815,22 @@ test_that("setting a different blank for the blank checker", {
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:1")
-  expect_match(result$feedback$message, "###")
+  expect_match(result$feedback$message, "This exercise contains 1 blank.")
+  expect_match(result$feedback$message, "Please replace <code>###</code> with valid code.")
 
   ex     <- mock_exercise(user_code = '####(####)', exercise.blanks = "###")
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:2")
+  expect_match(result$feedback$message, "This exercise contains 2 blanks.")
+  expect_match(result$feedback$message, "Please replace <code>###</code> with valid code.")
 
   ex     <- mock_exercise(user_code = '####("####")', exercise.blanks = "###")
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:2")
+  expect_match(result$feedback$message, "This exercise contains 2 blanks.")
+  expect_match(result$feedback$message, "Please replace <code>###</code> with valid code.")
 })
 
 test_that("setting a different blank for the blank checker in global setup", {
@@ -834,6 +844,9 @@ test_that("setting a different blank for the blank checker in global setup", {
   result <- evaluate_exercise(ex, new.env(), evaluate_global_setup = TRUE)
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:1")
+
+  expect_match(result$feedback$message, "This exercise contains 1 blank.")
+  expect_match(result$feedback$message, "Please replace <code>###</code> with valid code.")
 })
 
 test_that("setting a regex blank for the blank checker", {
@@ -844,10 +857,9 @@ test_that("setting a regex blank for the blank checker", {
   result <- evaluate_exercise(ex, new.env(), evaluate_global_setup = TRUE)
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:2")
-  expect_match(
-    result$feedback$message,
-    "\\.\\.function\\.\\..*\\$t\\(text.and\\).*\\.\\.string\\.\\."
-  )
+
+  expect_match(result$feedback$message, "This exercise contains 2 blanks.")
+  expect_match(result$feedback$message, "Please replace <code>..function..</code> and <code>..string..</code> with valid code.")
 })
 
 test_that("use underscores as blanks if exercise.blanks is TRUE", {
@@ -857,7 +869,8 @@ test_that("use underscores as blanks if exercise.blanks is TRUE", {
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:1")
-  expect_match(result$feedback$message, "____")
+  expect_match(result$feedback$message, "This exercise contains 1 blank.")
+  expect_match(result$feedback$message, "Please replace <code>____</code> with valid code.")
 
   ex <- mock_exercise(
     user_code = '____("test")', exercise.blanks = TRUE
@@ -865,7 +878,8 @@ test_that("use underscores as blanks if exercise.blanks is TRUE", {
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_for_blanks(ex)$feedback)
   expect_match(result$feedback$message, "&quot;count&quot;:1")
-  expect_match(result$feedback$message, "____")
+  expect_match(result$feedback$message, "This exercise contains 1 blank.")
+  expect_match(result$feedback$message, "Please replace <code>____</code> with valid code.")
 })
 
 test_that("default message if exercise.blanks is FALSE", {
@@ -882,6 +896,10 @@ test_that("default message if exercise.blanks is FALSE", {
   result <- evaluate_exercise(ex, new.env())
   expect_null(exercise_check_code_for_blanks(ex))
   expect_match(result$feedback$message, "text.unparsable")
+  expect_match(
+    result$feedback$message, i18n_translations()$en$translation$text$unparsable,
+    fixed = TRUE
+  )
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
 })
 
@@ -893,18 +911,30 @@ test_that("evaluate_exercise() returns a message if code is unparsable", {
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
+  expect_match(
+    result$feedback$message, i18n_translations()$en$translation$text$unparsable,
+    fixed = TRUE
+  )
   expect_match(result$error_message, "unexpected end of input")
 
   ex     <- mock_exercise(user_code = 'print("test)')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
+  expect_match(
+    result$feedback$message, i18n_translations()$en$translation$text$unparsable,
+    fixed = TRUE
+  )
   expect_match(result$error_message, "unexpected INCOMPLETE_STRING")
 
   ex     <- mock_exercise(user_code = 'mean(1:10 na.rm = TRUE)')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
+  expect_match(
+    result$feedback$message, i18n_translations()$en$translation$text$unparsable,
+    fixed = TRUE
+  )
   expect_match(result$error_message, "unexpected symbol")
 })
 


### PR DESCRIPTION
Modifies calls to `i18n_span()` in `evaluate_exercise()` to include default English text. This provides a fallback in cases where `i18next` fails to render text.

Closes #584.