### PR TITLE
Hand off parse error to error checker if one is available

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -340,12 +340,19 @@ evaluate_exercise <- function(
   }
 
   if (evaluate_global_setup) {
-    tryCatch({
-      eval(parse(text = exercise$global_setup), envir = envir)
-      NULL
-    }, error = function(err) {
-      exercise_result_error()
-    })
+    res_global <-
+      tryCatch({
+        eval(parse(text = exercise$global_setup), envir = envir)
+        NULL
+      }, error = function(err) {
+        message("Error evaluating global setup for exercise '", exercise$label, "': ", conditionMessage(err))
+        exercise_result_error(
+          "An internal error occurred while setting up the tutorial. Please try again or contact the tutorial author."
+        )
+      })
+    if (is_exercise_result(res_global)) {
+      return(res_global)
+    }
   }
 
   # Check if user code has unfilled blanks ----------------------------------

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -90,9 +90,6 @@ setup_exercise_handler <- function(exercise_rx, session) {
       exercise$check <- NULL
       exercise$code_check <- NULL
       exercise$error_check <- NULL
-    } else {
-      # If there is no locally defined error check code, look for globally defined error check option
-      exercise$error_check <- exercise$error_check %||% exercise$options$exercise.error.check.code
     }
 
     # get timelimit option (either from chunk option or from global option)
@@ -415,7 +412,8 @@ evaluate_exercise <- function(
         # checking: the exercise could be to throw an error!
         error_feedback <- try_checker(
           exercise,
-          check_code = exercise$error_check,
+          # If there is no locally defined error check code, look for globally defined error check option
+          check_code = exercise$error_check %||% exercise$options$exercise.error.check.code,
           envir_result = err_render$envir_result,
           evaluate_result = err_render$evaluate_result,
           envir_prep = err_render$envir_prep,

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -850,7 +850,7 @@ exercise_check_code_is_parsable <- function(exercise) {
   }
 
   # apply the error checker to the parse error, if there is an error
-  if (nzchar(exercise$error_check)) {
+  if (nzchar(exercise$error_check %||% "")) {
     error_feedback <- try_checker(
       exercise,
       check_code = exercise[["error_check"]],

--- a/R/mock_exercise.R
+++ b/R/mock_exercise.R
@@ -42,7 +42,8 @@ mock_exercise <- function(
     fig.num = 0,
     exercise.df_print = exercise.df_print,
     exercise.warn_invisible = exercise.warn_invisible,
-    exercise.timelimit = exercise.timelimit
+    exercise.timelimit = exercise.timelimit,
+    exercise.error.check.code = exercise.error.check.code
   )
 
   has_exercise_chunk <- any(

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -954,6 +954,17 @@ test_that("evaluate_exercise() passes parse error to explicit exercise checker f
   expect_equal(res$feedback, exercise_check_code_is_parsable(ex)$feedback)
 })
 
+test_that("Errors with global setup code result in an internal error", {
+  ex <- mock_exercise(global_setup = "stop('boom')")
+  expect_message(
+    res <- evaluate_exercise(ex, new.env(), evaluate_global_setup = TRUE),
+    "global setup"
+  )
+
+  expect_match(res$error_message, "internal error occurred while setting up the tutorial")
+  expect_match(format(res$html_output), "internal error occurred while setting up the tutorial")
+})
+
 
 # Timelimit ---------------------------------------------------------------
 

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -938,6 +938,22 @@ test_that("evaluate_exercise() returns a message if code is unparsable", {
   expect_match(result$error_message, "unexpected symbol")
 })
 
+test_that("evaluate_exercise() passes parse error to explicit exercise checker function", {
+  ex <- mock_exercise(
+    "_foo",
+    check = "check",
+    error_check = "error_check",
+    exercise.error.check.code = "default_error_check"
+  )
+
+  res <- evaluate_exercise(ex, new.env())
+  expect_equal(res$feedback$checker_args$check_code, "error_check")
+
+  ex$error_check <- ""
+  res <- evaluate_exercise(ex, new.env())
+  expect_equal(res$feedback, exercise_check_code_is_parsable(ex)$feedback)
+})
+
 
 # Timelimit ---------------------------------------------------------------
 


### PR DESCRIPTION
1. Errors that happen when evaluating `global_setup` in `evaluate_exercise()` are now returned as internal errors
2. We no longer globally copy `exercise.error.check.code` into `error_check`, instead we do that operation when we actually go to evaluate the error checker. This lets us tell the difference between a global default option and an explicit error checker.
3. The parse error checker now runs the parse error through the error checker if one is available (and it's not the default error checker).