### PR TITLE
Update tutorial pandoc template for head content in header-includes

### DIFF
--- a/R/tutorial-format.R
+++ b/R/tutorial-format.R
@@ -121,10 +121,14 @@ tutorial <- function(fig_width = 6.5,
     )
   ))
 
-  # additional pandoc variables
+  # additional pandoc variables specific to learnr
   jsbool <- function(value) ifelse(value, "true", "false")
-  args <- c(args, rmarkdown::pandoc_variable_arg("progressive", jsbool(progressive)))
-  args <- c(args, rmarkdown::pandoc_variable_arg("allow-skip", jsbool(allow_skip)))
+  args <- c(
+    args,
+    rmarkdown::pandoc_variable_arg("progressive", jsbool(progressive)),
+    rmarkdown::pandoc_variable_arg("allow-skip", jsbool(allow_skip)),
+    rmarkdown::pandoc_variable_arg("learnr-version", utils::packageVersion("learnr"))
+  )
 
   # knitr and pandoc options
   knitr_options <- rmarkdown::knitr_options_html(fig_width, fig_height, fig_retina, keep_md = FALSE , dev)

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -49,9 +49,22 @@ if (window.hljs) {
 </script>
 $endif$
 
+$if(highlighting-css)$
+<style type="text/css">code{white-space: pre;}</style>
+<style type="text/css">
+$highlighting-css$
+</style>
+$if(theme)$
+<style type="text/css">
+  pre:not([class]) {
+    background-color: white;
+  }
+</style>
+$endif$
+$endif$
+
 <!-- taken from https://github.com/rstudio/rmarkdown/blob/67b7f5fc779e4cfdfd0f021d3d7745b6b6e17149/inst/rmd/h/default.html#L296-L362 -->
 <!-- tabsets -->
-
 <style type="text/css">
 .tabset-dropdown > .nav-tabs {
   display: inline-table;
@@ -106,20 +119,6 @@ $endif$
 }
 </style>
 <!-- end tabsets -->
-
-$if(highlighting-css)$
-<style type="text/css">code{white-space: pre;}</style>
-<style type="text/css">
-$highlighting-css$
-</style>
-$if(theme)$
-<style type="text/css">
-  pre:not([class]) {
-    background-color: white;
-  }
-</style>
-$endif$
-$endif$
 
 $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -21,7 +21,6 @@ $endif$
 
 <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 
-
 <!-- header-includes START -->
 $for(header-includes)$
 $header-includes$

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -63,7 +63,7 @@ $if(theme)$
 $endif$
 $endif$
 
-<!-- taken from https://github.com/rstudio/rmarkdown/blob/67b7f5fc779e4cfdfd0f021d3d7745b6b6e17149/inst/rmd/h/default.html#L296-L362 -->
+<!-- taken from https://github.com/rstudio/rmarkdown/blob/de8a9c38618903627ca509f5401d50a0876079f7/inst/rmd/h/default.html#L293-L343 -->
 <!-- tabsets -->
 <style type="text/css">
 .tabset-dropdown > .nav-tabs {
@@ -71,7 +71,6 @@ $endif$
   max-height: 500px;
   min-height: 44px;
   overflow-y: auto;
-  background: white;
   border: 1px solid #ddd;
   border-radius: 4px;
 }
@@ -107,6 +106,7 @@ $endif$
   border: none;
   display: inline-block;
   border-radius: 4px;
+  background-color: transparent;
 }
 
 .tabset-dropdown > .nav-tabs.nav-tabs-open > li {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.htm
@@ -18,6 +18,7 @@ $endif$
 
 <meta name="progressive" content="$progressive$" />
 <meta name="allow-skip" content="$allow-skip$" />
+<meta name="learnr-version-prerender" content="$learnr-version$" />
 
 <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 


### PR DESCRIPTION
In preparation for upcoming changes in rmarkdown that will move the dynamically inserted `HEAD_CONTENT` to the end of the `header-includes` list.

Moves `<!-- HEAD_CONTENT -->` to just after `$header-includes$` section so that behavior before and after rstudio/rmarkdown#2249 will be more or less equivalent.