### PR TITLE
Only collect forked evaluator results once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,8 @@
 
 -   Support the updated Bootstrap 4+ popover dispose method name, previously destroy (#560).
 
+-   Forked evaluator (used by default on Linux and [shinyapps.io](https://shinyapps.io)) now only collects the exercise evaluation result once, avoiding a "cannot wait for child" warning (thanks @tombeesley #449, #631).
+
 # learnr 0.10.1
 
 ## New features

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -47,10 +47,11 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
     # helper to call a hook function
     call_hook <- function(name, default = NULL) {
       hook <- getOption(paste0("tutorial.exercise.evaluator.", name))
-      if (!is.null(hook))
+      if (!is.null(hook)) {
         hook(job$pid)
-      else if (!is.null(default))
+      } else if (!is.null(default)) {
         default(job$pid)
+      }
     }
 
     # default cleanup function
@@ -113,14 +114,15 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           result <<- collect[[1]]
 
           # check if it's an error and convert it to an html error if it is
-          if(inherits(result, "try-error"))
+          if (inherits(result, "try-error")) {
             result <<- exercise_result_error(result, timeout_exceeded = FALSE)
+          }
 
-          TRUE
+          return(TRUE)
         }
 
         # hit timeout
-        else if (difftime(Sys.time(), start_time, units="secs") >= timelimit) {
+        if (difftime(Sys.time(), start_time, units="secs") >= timelimit) {
 
           # call cleanup hook
           call_hook("oncleanup", default = default_cleanup)
@@ -128,15 +130,13 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           # decrement our counter of processes
           running_exercises <<- running_exercises - 1
 
-          # return error result
+          # store error result
           result <<- exercise_result_timeout()
-          TRUE
+          return(TRUE)
         }
 
         # not yet completed
-        else {
-          FALSE
-        }
+        FALSE
       },
 
       result = function() {

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -39,18 +39,16 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 
   function(expr, timelimit, ...) {
 
-    # closure members
-    job <- NULL
-    start_time <- NULL
-    result <- NULL
+    # closure object to track job, start time and result
+    self <- list()
 
     # helper to call a hook function
     call_hook <- function(name, default = NULL) {
       hook <- getOption(paste0("tutorial.exercise.evaluator.", name))
       if (!is.null(hook)) {
-        hook(job$pid)
+        hook(self$job$pid)
       } else if (!is.null(default)) {
-        default(job$pid)
+        default(self$job$pid)
       }
     }
 
@@ -62,7 +60,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
     list(
 
       start = function() {
-        start_time <<- Sys.time()
+        self$start_time <<- Sys.time()
 
         doStart <- function(){
           if (running_exercises >= max_forked_procs) {
@@ -75,7 +73,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           # increment our counter of processes
           running_exercises <<- running_exercises + 1
 
-          job <<- parallel::mcparallel(mc.interactive = FALSE, {
+          self$job <<- parallel::mcparallel(mc.interactive = FALSE, {
 
             # close all connections
             closeAllConnections()
@@ -91,16 +89,18 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
       },
 
       completed = function() {
-        if (is.null(start_time)) {
+        if (!"start_time" %in% names(self)) {
+          # Evaluation hasn't started, can't call mccollect() yet
           return(NA)
         }
 
-        if (!is.null(result)) {
+        if ("result" %in% names(self)) {
+          # Collected result has replaced placeholder unresolved result
           return(TRUE)
         }
 
         # attempt to collect the result
-        collect <- parallel::mccollect(jobs = job, wait = FALSE, timeout = 0.01)
+        collect <- parallel::mccollect(jobs = self$job, wait = FALSE, timeout = 0.01)
 
         # got result
         if (!is.null(collect)) {
@@ -111,18 +111,18 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           running_exercises <<- running_exercises - 1
 
           # return result
-          result <<- collect[[1]]
+          self$result <<- collect[[1]]
 
           # check if it's an error and convert it to an html error if it is
-          if (inherits(result, "try-error")) {
-            result <<- exercise_result_error(result, timeout_exceeded = FALSE)
+          if (inherits(self$result, "try-error")) {
+            self$result <<- exercise_result_error(self$result, timeout_exceeded = FALSE)
           }
 
           return(TRUE)
         }
 
         # hit timeout
-        if (difftime(Sys.time(), start_time, units="secs") >= timelimit) {
+        if (difftime(Sys.time(), self$start_time, units="secs") >= timelimit) {
 
           # call cleanup hook
           call_hook("oncleanup", default = default_cleanup)
@@ -131,7 +131,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
           running_exercises <<- running_exercises - 1
 
           # store error result
-          result <<- exercise_result_timeout()
+          self$result <<- exercise_result_timeout()
           return(TRUE)
         }
 
@@ -140,7 +140,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
       },
 
       result = function() {
-        result
+        self$result
       }
     )
   }

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -96,10 +96,6 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
 
         # got result
         if (!is.null(collect)) {
-
-          # final reaping of process
-          parallel::mccollect(jobs = job, wait = FALSE)
-
           # call cleanup hook
           call_hook("oncleanup", default = default_cleanup)
 

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -90,6 +90,13 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
       },
 
       completed = function() {
+        if (is.null(start_time)) {
+          return(NA)
+        }
+
+        if (!is.null(result)) {
+          return(TRUE)
+        }
 
         # attempt to collect the result
         collect <- parallel::mccollect(jobs = job, wait = FALSE, timeout = 0.01)

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -95,7 +95,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
         }
 
         if ("result" %in% names(self)) {
-          # Collected result has replaced placeholder unresolved result
+          # We know the job is complete because we have a collected result
           return(TRUE)
         }
 

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -387,3 +387,28 @@ test_that("bad statuses or invalid json are handled sanely", {
   res <- e$result()
   expect_match(res$error_message, "^Error submitting external exercise")
 })
+
+test_that("forked_evaluator works as expected", {
+  skip_on_cran()
+  skip_if(is_windows(), message = "Skipping forked evaluator testing on Windows")
+
+  ex <- mock_exercise("Sys.sleep(1)\n1:100", check = I("last_value"))
+  forked_eval_ex <- forked_evaluator_factory(evaluate_exercise(ex, new.env()), 2)
+
+  # not yet started
+  expect_equal(forked_eval_ex$completed(), NA)
+  expect_null(forked_eval_ex$result())
+
+  # start evaluator and check that it's running (not completed)
+  forked_eval_ex$start()
+  # right away, the forked evaluator is *certainly* not complete yet
+  expect_silent(expect_equal(forked_eval_ex$completed(), FALSE))
+  # poll the forked evaluator until it's ready
+  while (!expect_silent(forked_eval_ex$completed())) {
+    Sys.sleep(0.1)
+  }
+  # when the evaluator is complete, we should be able to call $completed() again
+  expect_silent(expect_equal(forked_eval_ex$completed(), TRUE))
+  # finally check that $result() gives us our exercise feedback
+  expect_equal(forked_eval_ex$result()$feedback$checker_result, 1:100)
+})


### PR DESCRIPTION
As described in #339 and #449, learnr on Linux or with the forked evaluator generates a lot of `cannot wait for child...` errors when evaluating exercises. I think this warning started appearing around R 3.5 when trying to collect the results of an already collected forked job and stemmed from us calling `mccollect()` again once we already had the results.

https://github.com/rstudio/learnr/blob/b000739c03c1e3427fc3e709a49a6626b95365cb/R/evaluators.R#L94-L101

When the external evaluator was written ~5 years ago circa R 3.3, it's possible this step was required. But AFAICT from the source of `parallel::mccollect()`, this is no longer necessary. The `timeout` argument applies to _finding_ the forked process; if the process has finished it returns the complete result. Once a process completes, {parallel} expects users **not to collect again**, so our second call to `parallel::mccollect()` appears to be doing nothing more than throwing a warning:

```
Warning message:
In selectChildren(jobs, timeout) :
  cannot wait for child 43193 as it does not exist
```

https://github.com/wch/r-source/blob/8454163eed23ffd2703db55c85fa1f1576288308/src/library/parallel/R/unix/mcparallel.R#L65-L80

Fixes #339
Fixes #449