### PR TITLE
Refine exercise completion logic when `allow_skip = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,8 @@
 
 -   The `envir_prep` environment used in exercise checking now accurately captures the result of both global and exercise-specific setup code, representing the environment in which the user code will be evaluated (as was described in the documentation). learnr also ensures that `envir_result` (the environment containing the result of evaluating global, setup and user code) is a sibling of `envir_prep` (#480).
 
+-   When `allow_skip` is set to `FALSE`, users are now required to run an exercise once with non-empty code in order to move forward. If the exercise has grading code, users are required to submit one (non-empty) answer (thanks @gaelso #616, #633).
+
 ### Questions
 
 -   `question_text()` gains `rows` and `cols` parameters. If either is provided, a multi-line `textAreaInput()` is used for the text input (thanks @dtkaplan #455, #460).

--- a/R/events_default.R
+++ b/R/events_default.R
@@ -135,7 +135,7 @@ register_default_event_handlers <- function() {
   event_register_handler(
     "exercise_result",
     function(session, event, data) {
-      # Should this even count towards exercise completion?
+      # Should this event count towards exercise completion?
       ex <- standardize_exercise_code(get_exercise_cache(data$label))
       requires_check <- nzchar(ex$check) || nzchar(ex$code_check)
       # Only set `correct` on the `exercise_submission` event if a check was required

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -255,8 +255,10 @@ Tutorial.prototype.$fireProgressEvent = function(event, data) {
     if (element.length > 0) {
       progressEvent.element = element;
       if (event == "exercise_submission") {
-        // any progress event for an exercise is to complete only
-        progressEvent.completed = true;
+        // Exercise completion logic is determined by the default exercise_result
+        // event handler in the Shiny logic that emits an "exercise_submission" event.
+        // If the handler doesn't returned a completed flag, we assume `true`.
+        progressEvent.completed = typeof data.completed !== 'undefined' ? data.completed : true;
       } else {
         // question_submission
         // questions may be reset with "try again", and not in a completed state


### PR DESCRIPTION
Addresses #616 by augmenting the `exercise_submission` event to include a `completed` item. This boolean value indicates whether or not the submission should count toward the completion of the exercise and therefore the current section. This is primarily relevant when `allow_skip: false` is set in the tutorial YAML heading.

Previously, as described in #616, any exercise submission counted toward completion, including pressing "Run Code" on an empty exercise input. This will no longer be the case.

The new logic is set in the `exercise_result` event handler, which is where the `exercise_submission` event is emitted. There, we use the exercise cache to access the full exercise object and augment the `exercise_submission` event `data` with a new `completed` item. The full logic is to:

1. Only set `correct` when submission doesn't require a check
2. Add `completed` to the data. The flag is `TRUE` when there is submission code and
    - the exercise doesn't have any grading
    - OR the exercise has grading code (either `$check` or `$code_check`) _and_ the exercise was checked
3. The first event reporting `data.completed` causes the progress to move forward. (I haven't traced the logic, but testing indicates that the first completed event isn't erased by subsequent non-completion counting events).

The end result is that the user must make one non-empty "Run Code" submission for exercises without grading code or one "Submit Answer" submission for exercises with grading code in order to move forward. We do not, however, require that the answer be correct — in our experience limiting users in this way would cause more frustration than it's worth, since it's easy for mistakes in grading code to accidentally make "correctness" impossible.

One other limitation is that if the exercise has initial code, we don't impede progress if the user submits the initial code as it was provided. I think doing so would ultimately lead to issues down the line but I'd be open to revisiting that policy now that I understand the flow better.

https://user-images.githubusercontent.com/5420529/147611945-a0fe5cb3-d969-457e-8c36-4beb69dccde9.mp4

