### PR TITLE
Throw a warning from forked evaluators that behavior is inconsistent on Mac/Windows

### DIFF
--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -40,7 +40,7 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
   function(expr, timelimit, ...) {
     if (is_macos()) {
       rlang::warn("Forked evaluators may not work as expected on MacOS")
-    } else if (is_widows()) {
+    } else if (is_windows()) {
       rlang::warn("Forked evaluators may not work as expected on Windows")
     }
 

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -38,6 +38,11 @@ setup_forked_evaluator_factory <- function(max_forked_procs){
   running_exercises <- 0
 
   function(expr, timelimit, ...) {
+    if (is_macos()) {
+      rlang::warn("Forked evaluators may not work as expected on MacOS")
+    } else if (is_widows()) {
+      rlang::warn("Forked evaluators may not work as expected on Windows")
+    }
 
     # closure object to track job, start time and result
     self <- list()


### PR DESCRIPTION
It's a little noisy but I there isn't a much better place to emit this message since we call `setup_forked_evaluator_factory()` internally. Regardless, it would only be annoying for those who opt into the forked evaluator on Mac/Windows
