### PR TITLE
Skip tests that use pandoc if pandoc version < 1.14

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,24 @@
+
+# https://github.com/rstudio/rmarkdown/blob/2faee0040a39008a47bdf1ba840bf402cba15a65/tests/testthat/helpers.R
+
+skip_if_not_pandoc <- function(ver = NULL) {
+  if (!rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is not available"
+    } else {
+      sprintf("Version of Pandoc is lower than %s.", ver)
+    }
+    skip(msg)
+  }
+}
+
+skip_if_pandoc <- function(ver = NULL) {
+  if (rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is available"
+    } else {
+      sprintf("Version of Pandoc is greater than %s.", ver)
+    }
+    skip(msg)
+  }
+}

--- a/tests/testthat/test-knitr-hooks.R
+++ b/tests/testthat/test-knitr-hooks.R
@@ -1,4 +1,6 @@
 test_that("Error thrown: has -check chunk but missing exercise.checker", {
+  skip_if_not_pandoc("1.14")
+
   rmd <- test_path("tutorials", "missing-exercise-checker.Rmd")
 
   withr::with_tempfile("outfile", fileext = ".html", {
@@ -10,7 +12,7 @@ test_that("Error thrown: has -check chunk but missing exercise.checker", {
 })
 
 test_that("*-error-check chunks require *-check chunks", {
-  skip_if_not(rmarkdown::pandoc_available())
+  skip_if_not_pandoc("1.14")
 
   tmpfile <- tempfile(fileext = ".html")
   on.exit(unlink(tmpfile))
@@ -27,7 +29,7 @@ test_that("*-error-check chunks require *-check chunks", {
 })
 
 test_that("Detection of chained setup cycle works", {
-  skip_if_not(rmarkdown::pandoc_available())
+  skip_if_not_pandoc("1.14")
 
   tmpfile <- tempfile(fileext = ".html")
   on.exit(unlink(tmpfile))

--- a/tests/testthat/test-options-reveal_solution.R
+++ b/tests/testthat/test-options-reveal_solution.R
@@ -1,6 +1,8 @@
 context("Optionally reveal solution")
 
 render_tutorial_with_reveal_solution <- function(opt_string) {
+  skip_if_not_pandoc("1.14")
+
   ex <- readLines(test_path("tutorials", "optional-show-solution.Rmd"))
   ex <- sub("#<<reveal_solution>>", opt_string, ex, fixed = TRUE)
 


### PR DESCRIPTION
Fixes tests that fail on https://rstudio.r-universe.dev for windows, which will also likely fail on CRAN, by skipping when a recent-enough version of pandoc is not available.

https://github.com/r-universe/rstudio/runs/4924603994?check_suite_focus=true