### PR TITLE
Progressively enhance docs with ace editor

### DIFF
--- a/man/rmd-fragments/hello-tutorial.Rmd
+++ b/man/rmd-fragments/hello-tutorial.Rmd
@@ -1,12 +1,12 @@
-To create a tutorial, set `runtime: shiny_prerendered` in the YAML fromtmatter of your `.Rmd` file to turn your R Markdown document into an [interactive app](https://rmarkdown.rstudio.com/lesson-14.html). 
+To create a tutorial, set `runtime: shiny_prerendered` in the YAML frontmatter of your `.Rmd` file to turn your R Markdown document into an [interactive app](https://rmarkdown.rstudio.com/lesson-14.html).
 
 Then, call `library(learnr)` within your Rmd file to activate tutorial mode, and use the `exercise = TRUE` chunk option to turn code chunks into exercises. Users can edit and execute the R code and see the results right within their browser.
 
 For example, here's a very simple tutorial:
 
-```{=html}
-<div id="hellotutor"></div>
-<script type="text/javascript">loadSnippet('hellotutor')</script>
+```{r snippet-hello-learnr, echo = FALSE}
+source("../../vignettes/articles/snippets.R")
+insert_snippet("hello-learnr")
 ```
 
 This is what the running tutorial document looks like after the user has entered their answer:

--- a/pkgdown/assets/snippets/hello-learnr.md
+++ b/pkgdown/assets/snippets/hello-learnr.md
@@ -8,7 +8,8 @@ runtime: shiny_prerendered
 library(learnr)
 ```
 
-This code computes the answer to one plus one, change it so it computes two plus two:
+This code computes the answer to one plus one,
+change it so it computes two plus two:
 
 ```{r addition, exercise=TRUE}
 1 + 1

--- a/pkgdown/assets/snippets/snippets.js
+++ b/pkgdown/assets/snippets/snippets.js
@@ -2,8 +2,7 @@
 
 function loadSnippet(snippet, mode) {
   mode = mode || "r";
-  $("#" + snippet).addClass("snippet");
-  var editor = ace.edit(snippet);
+  const editor = ace.edit(snippet);
   editor.setHighlightActiveLine(false);
   editor.setShowPrintMargin(false);
   editor.setReadOnly(true);
@@ -16,13 +15,7 @@ function loadSnippet(snippet, mode) {
   editor.session.setMode("ace/mode/" + mode);
   editor.session.getSelection().clearSelection();
 
-  // create element to hold the snippet for screen readers
-  const pre = document.createElement('pre')
-  pre.classList = 'markdown sr-only'
-  const code = document.createElement('code')
-  pre.appendChild(code)
-
-  var root = document.querySelector('meta[name="pkgdown-site-root"]').content
+  const root = document.querySelector('meta[name="pkgdown-site-root"]').content;
   $.get(root + "snippets/" + snippet + ".md", function(data) {
     // Write the snippet into the editor
     editor.setValue(data, -1);
@@ -30,8 +23,9 @@ function loadSnippet(snippet, mode) {
       maxLines: editor.session.getLength()
     });
 
-    // and write the snippet into the screen reader element
-    code.innerHTML = data;
-    editor.container.insertBefore(pre, editor.container.firstChild);
+    // and write the snippet into an element for screen readers
+    const pre = $('<pre class="markdown sr-only"></pre>')
+      .append($('<code></code>').text(data));
+    $(editor.container).prepend(pre);
   });
 }

--- a/pkgdown/assets/snippets/snippets.js
+++ b/pkgdown/assets/snippets/snippets.js
@@ -2,6 +2,7 @@
 
 function loadSnippet(snippet, mode) {
   mode = mode || "r";
+  $("#" + snippet).addClass("snippet").removeClass('sourceCode');
   const editor = ace.edit(snippet);
   editor.setHighlightActiveLine(false);
   editor.setShowPrintMargin(false);

--- a/pkgdown/assets/snippets/snippets.js
+++ b/pkgdown/assets/snippets/snippets.js
@@ -16,11 +16,22 @@ function loadSnippet(snippet, mode) {
   editor.session.setMode("ace/mode/" + mode);
   editor.session.getSelection().clearSelection();
 
+  // create element to hold the snippet for screen readers
+  const pre = document.createElement('pre')
+  pre.classList = 'markdown sr-only'
+  const code = document.createElement('code')
+  pre.appendChild(code)
+
   var root = document.querySelector('meta[name="pkgdown-site-root"]').content
   $.get(root + "snippets/" + snippet + ".md", function(data) {
+    // Write the snippet into the editor
     editor.setValue(data, -1);
     editor.setOptions({
       maxLines: editor.session.getLength()
     });
+
+    // and write the snippet into the screen reader element
+    code.innerHTML = data;
+    editor.container.insertBefore(pre, editor.container.firstChild);
   });
 }

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -91,7 +91,7 @@ Here are some examples of tutorials created with the **learnr** package.
 ## Hello, Tutorial!
 
 To create a tutorial, set `runtime: shiny_prerendered` in the YAML
-fromtmatter of your `.Rmd` file to turn your R Markdown document into an
+frontmatter of your `.Rmd` file to turn your R Markdown document into an
 [interactive app](https://rmarkdown.rstudio.com/lesson-14.html).
 
 Then, call `library(learnr)` within your Rmd file to activate tutorial
@@ -101,8 +101,26 @@ results right within their browser.
 
 For example, here’s a very simple tutorial:
 
-<div id="hellotutor"></div>
-<script type="text/javascript">loadSnippet('hellotutor')</script>
+<div id="hello-learnr" class="sourceCode">
+<pre class="markdown">
+<code>---
+title: "Hello, Tutorial!"
+output: learnr::tutorial
+runtime: shiny_prerendered
+---
+
+&#96;&#96;&#96;{r setup, include=FALSE}
+library(learnr)
+&#96;&#96;&#96;
+
+This code computes the answer to one plus one, change it so it computes two plus two:
+
+&#96;&#96;&#96;{r addition, exercise=TRUE}
+1 + 1
+&#96;&#96;&#96;</code>
+</pre>
+</div>
+<script type="text/javascript">loadSnippet('hello-learnr')</script>
 
 This is what the running tutorial document looks like after the user has
 entered their answer:

--- a/vignettes/articles/exercises.Rmd
+++ b/vignettes/articles/exercises.Rmd
@@ -70,8 +70,10 @@ Exercises are interactive R code chunks that allow readers to directly execute R
 
 Note that these options can all be specified either globally or per-chunk. For example, the following code sets global default options using the `setup` chunk and also sets some local options on the `addition` chunk:
 
-<div id="exerciseoptions"></div>
-<script type="text/javascript">loadSnippet('exerciseoptions')</script>
+```{r snippet-exerciseoptions, echo = FALSE}
+source("snippets.R")
+insert_snippet("exerciseoptions")
+```
 
 There are also some other specialized chunks that can be used with an exercise chunk, including:
 
@@ -88,8 +90,9 @@ By default, exercise code chunks are NOT pre-evaluated (i.e there is no initial 
 
 You can arrange for an exercise to be pre-evaluated (and its output shown) using the `exercise.eval` chunk option. This option can also be set either globally or per-chunk:
 
-<div id="exerciseeval"></div>
-<script type="text/javascript">loadSnippet('exerciseeval')</script>
+```{r snippet-exerciseeval, echo = FALSE}
+insert_snippet("exerciseeval")
+```
 
 ## Exercise Setup
 
@@ -109,38 +112,38 @@ Each of these is described in more detail below. Note that you may also [chain s
 
 Code in the global `setup` chunk is run once at the startup of the tutorial and is shared by all exercises within the tutorial. For example:
 
-<div id="exercisesetup" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisesetup')</script>
-    
+```{r snippet-exercisesetup, echo = FALSE}
+insert_snippet("exercisesetup")
+```
 #### Create a shared setup chunk {#setup-shared}
 
 If you don't want to rely on global setup but would rather create setup code that's used by only a handful of exercises you can use the `exercise.setup` chunk attribute to provide the label of another chunk that will perform setup tasks. To illustrate, we'll re-write the previous example to use a shared setup chunk named `prepare-flights`:
 
-<div id="exercisesetupshared" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisesetupshared')</script>
-
+```{r snippet-exercisesetupshared, echo = FALSE}
+insert_snippet("exercisesetupshared")
+```
 #### Create an exercise-specific `-setup` chunk {#setup-exercise-specific}
 
 **learnr** will automatically associate any chunk with a label in the format `<exercise>-setup` as a setup chunk specifically associated with `<exercise>`, where `<exercise>` is replaced with the label of the exercise chunk. For example, the `filter-setup` chunk will be used as the setup chunk for the `filter` exercise:
 
-<div id="exercisesetupsuffix" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisesetupsuffix')</script>
-    
+```{r snippet-exercisesetupsuffix, echo = FALSE}
+insert_snippet("exercisesetupsuffix")
+```
 #### Chained setup chunks {#setup-chained}
 
 If may also chain setup chunks where each setup chunk inherits its parent setup chunk using the `exercise.setup` chunk option. (**Note**: You must use `exercise.setup` for chaining. You cannot rely on the `-setup` suffix labelling scheme.) **learnr** will keep following the trail of `exercise.setup` chunks until there are no more chunks to be found. To demonstrate, we can convert the first exercise in the above examples to be another setup chunk called `filtered-flights` with its `exercise.setup=prepare-flights`. This will now filter the data and store it and can be referenced inside the `arrange` exercise:
 
-<div id="exercisesetupchained" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisesetupchained')</script>
-
+```{r snippet-exercisesetupchained, echo = FALSE}
+insert_snippet("exercisesetupchained")
+```
 You can chain use exercise chunks in the setup chunk chain, but keep in mind that the code as it appears in the R Markdown source is used to serve as the setup code, not the user input. For example, if you turned `filtered-flights` back to an exercise, the pre-filled code is used as setup for the `arrange` exercise that use it as its setup:
 
-<div id="exercisechained" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisechained')</script>
-    
+```{r snippet-exercisechained, echo = FALSE}
+insert_snippet("exercisechained")
+```
 ### Using Files in Exercises
 
-Occasionally, you may write an exercise that requires users to interact with files on disk, such as data files in `.csv` or `.rds` format. **learnr** will look for a folder named `data/` in the same directory as the tutorial source and, if present, will make this directory available to users in all exercises in the tutorial. 
+Occasionally, you may write an exercise that requires users to interact with files on disk, such as data files in `.csv` or `.rds` format. **learnr** will look for a folder named `data/` in the same directory as the tutorial source and, if present, will make this directory available to users in all exercises in the tutorial.
 
 To ensure consistency between each evaluation of the user's code, users interact with a temporary copy of the original directory. This way, users cannot overwrite or delete the original files. Additionally, in the exercise, the directory is always called `data/`.
 
@@ -154,9 +157,9 @@ There are three ways authors can include files for use in exercises:
 
 In the example below, the global setup chunk is used to write `data/flights_jan.csv` and users are asked to load this file with `read_csv()`.
 
-<div id="exercisedata" style="width: 95%;"></div>
-<script type="text/javascript">loadSnippet('exercisedata')</script>
-
+```{r snippet-exercisedata, echo = FALSE}
+insert_snippet("exercisedata")
+```
 ## Hints and Solutions
 
 You can optionally provide a hint or solution for each exercise that can be optionally displayed by users. Hints can be based on either R code snippets or on custom markdown/HTML content.
@@ -165,9 +168,9 @@ You can optionally provide a hint or solution for each exercise that can be opti
 
 To create a hint or solution based on R code simply create a new code chunk with "-hint" or "-solution" chunk label suffix. For example:
 
-<div id="exercisesolution"></div>
-<script type="text/javascript">loadSnippet('exercisesolution')</script>
-
+```{r snippet-exercisesolution, echo = FALSE}
+insert_snippet("exercisesolution")
+```
 A "Hint" or "Solution" button is added to the left side of the exercise header region:
 
 <img src="images/solution.png"  width="732" height="183"/>
@@ -176,39 +179,39 @@ A "Hint" or "Solution" button is added to the left side of the exercise header r
 
 To create a hint based on custom markdown content simply add a `<div>` tag with an `id` attribute that marks it as hint for your exercise (e.g. "filter-hint"). For example:
 
-<div id="exercisehintdiv"></div>
-<script type="text/javascript">loadSnippet('exercisehintdiv', 'markdown')</script>
-
+```{r snippet-exercisehintdiv, echo = FALSE}
+insert_snippet("exercisehintdiv")
+```
 The content within the `<div>` will be displayed underneath the R code editor for the exercise whenever the user presses the "Hint" button.
 
 ### Multiple Hints
 
 For R code hints you can provide a sequence of hints that reveal progressively more of the solution as desired by the user. To do this create a sequence of indexed hint chunks (e.g. "-hint-1", "-hint-2, "-hint-3", etc.) for your exercise chunk. For example:
 
-<div id="exercisehints"></div>
-<script type="text/javascript">loadSnippet('exercisehints')</script>
-
+```{r snippet-exercisehints, echo = FALSE}
+insert_snippet("exercisehints")
+```
 ### Hiding Solutions
 
 By default, the exercise solution is made available to the user with the "Solution" or "Hint" button (if there are hints those will appear first). If you would prefer not to reveal the solution to an exercise, you can disable revealing the solution by adding `exercise.reveal_solution = FALSE` to the chunk options of either the exercise or its corresponding `*-solution` chunk.
 
-<div id="exercisesolutionhidden"></div>
-<script type="text/javascript">loadSnippet('exercisesolutionhidden')</script>
-
+```{r snippet-exercisesolutionhidden, echo = FALSE}
+insert_snippet("exercisesolutionhidden")
+```
 You can also set this option globally in the global `setup` chunk with `tutorial_options()`. When set this way, the chunk-level option will take precedence over the global option so that you can choose to always reveal or hide the solution to a particular exercise. The current default is to reveal exercise solutions, but in a future version of learnr the default behavior will change to hide solutions.
 
 ## Progressive Reveal
 
 You might want users of your tutorials to see only one sub-topic at a time as they work through the material (this can be helpful to reduce distractions and maintain focus on the current task). If you specify the `progressive` option then all Level 3 headings (`###`) will be revealed progressively. For example:
 
-<div id="tutorialyaml-progressive"></div>
-<script type="text/javascript">loadSnippet('tutorialyaml-progressive', 'markdown')</script>
-
+```{r snippet-tutorialyaml-progressive, echo = FALSE}
+insert_snippet("tutorialyaml-progressive")
+```
 You can also specify this option on a per topic basis using the `data-progressive` attribute. For example, the following code enables progressive rendering for a single topic:
 
-<div id="tutorialyaml-progressive-topic"></div>
-<script type="text/javascript">loadSnippet('tutorialyaml-progressive-topic', 'markdown')</script>
-
+```{r snippet-tutorialyaml-progressive-topic, echo = FALSE}
+insert_snippet("tutorialyaml-progressive-topic")
+```
 You can also use `data-progressive=FALSE` to disable progressive rendering for an individual topic if the global `progressive` option is `TRUE`.
 
 Progressive reveal provides an easy way to cue exercises one at a time: place each exercise under its own Level 3 header (`###`). This can be useful when a second exercises builds on the first, giving away the answer to the first.
@@ -223,14 +226,14 @@ You may want to allow users of your tutorials to skip through exercises that the
 
 If you specify the `allow_skip` option then students will be able to advance through a sub-section without completing the exercises. For example:
 
-<div id="tutorialyaml-allowskip"></div>
-<script type="text/javascript">loadSnippet('tutorialyaml-allowskip', 'markdown')</script>
-
+```{r snippet-tutorialyaml-allowskip, echo = FALSE}
+insert_snippet("tutorialyaml-allowskip")
+```
 You can also specify this option on a per sub-topic basis using the `data-allow-skip` attribute. For example, the following code enables exercise skipping within a single sub-topic:
 
-<div id="tutorialyaml-allowskip-topic"></div>
-<script type="text/javascript">loadSnippet('tutorialyaml-allowskip-topic', 'markdown')</script>
-
+```{r snippet-tutorialyaml-allowskip-topic, echo = FALSE}
+insert_snippet("tutorialyaml-allowskip-topic")
+```
 You can also use `data-allow-skip=FALSE` to disable exercise skipping rendering for an individual sub-topic if the global `allow-skip` option is `TRUE`.
 
 ## Exercise Checking
@@ -241,9 +244,9 @@ You can also use `data-allow-skip=FALSE` to disable exercise skipping rendering 
 
 Checking of exercise results may be done through a `*-check` chunk. With a **gradethis** setup, results can be graded with `grade_result()`, like so:
 
-<div id="exercisecheck"></div>
-<script type="text/javascript">loadSnippet('exercisecheck')</script>
-
+```{r snippet-exercisecheck, echo = FALSE}
+insert_snippet("exercisecheck")
+```
 When an exercise `*-check` chunk is provided, **learnr** provides an additional "Submit Answer" button, which allows users to experiment with various answers before formally submitting an answer:
 
 <img src="images/exercise-result.png" width="100%" style="border: 1px solid #ddd; box-shadow:5px 5px 5px #eee;"/>
@@ -252,9 +255,9 @@ When an exercise `*-check` chunk is provided, **learnr** provides an additional 
 
 Checking of exercise *code* may be done through a `*-code-check` chunk. With a **gradethis** setup, if you supply a `*-solution` chunk and call `grade_code()` inside `*-code-check`, then you get detection of differences in the R syntax between the submitted exercise code and the solution code.
 
-<div id="exercisecodecheck"></div>
-<script type="text/javascript">loadSnippet('exercisecodecheck')</script>
-
+```{r snippet-exercisecodecheck, echo = FALSE}
+insert_snippet("exercisecodecheck")
+```
 <img src="images/exercise-code.png" width="100%" style="border: 1px solid #ddd; box-shadow:5px 5px 5px #eee;"/>
 
 It's worth noting that, when a `*-code-check` chunk is supplied, the check is done *prior* to evaluation of the exercise submission, meaning that if the `*-code-check` chunk returns feedback, then that feedback is displayed, no exercise code is evaluated, and no result check is performed.
@@ -263,9 +266,9 @@ It's worth noting that, when a `*-code-check` chunk is supplied, the check is do
 
 Occasionally, you may include blanks in the pre-filled code in your exercise prompts --- sections of the code in the exercise prompt that students should fill in. By default, **learnr** will detect sequences of three or more underscores, e.g. `____` as blanks, regardless of where they appear in the user's submitted code.
 
-<div id="exerciseblanks"></div>
-<script type="text/javascript">loadSnippet('exerciseblanks')</script>
-
+```{r snippet-exerciseblanks, echo = FALSE}
+insert_snippet("exerciseblanks")
+```
 <img src="images/exercise-blanks.png" width="100%" style="border: 1px solid #ddd; box-shadow:5px 5px 5px #eee;"/>
 
 You can choose your own blank pattern by setting the `exercise.blanks` chunk option to a regular expression  that identifies your blanks. You may also set `exercise.blanks = TRUE` to use the default **learnr** blank pattern, or `exercise.blanks = FALSE` to skip blank checking altogether. Globally `tutorial_options()` can be used to set the value of this argument for all exercises.
@@ -274,7 +277,7 @@ Submitted code with blanks will still be evaluated, but the other exercise check
 
 ### Checking Errors
 
-In the event that an exercise submission generates an error, checking of the code (or its result, which is an error condition) may be done through either a `*-error-check` chunk or through the global `exercise.error.check.code` option. If an `*-error-check` chunk is provided, you must also include a `*-check` chunk, typically to provide feedback in case the submission _doesn't_ generate an error. 
+In the event that an exercise submission generates an error, checking of the code (or its result, which is an error condition) may be done through either a `*-error-check` chunk or through the global `exercise.error.check.code` option. If an `*-error-check` chunk is provided, you must also include a `*-check` chunk, typically to provide feedback in case the submission _doesn't_ generate an error.
 
 With a **gradethis** setup, `exercise.error.check.code` is set to `grade_code()`. This means that, by default, users will receive intelligent feedback for a submission that generates an error using the `*-solution` chunk, if one is provided.
 
@@ -330,9 +333,9 @@ If, at any one of these stages, feedback should be provided, then `exercise.chec
 
 Below is a rough sketch of how one might implement an `exercise.checker` function.
 
-<div id="customchecker"></div>
-<script type="text/javascript">loadSnippet('customchecker')</script>
-
+```{r snippet-customchecker, echo = FALSE}
+insert_snippet("customchecker")
+```
 See the table below for a full description of all the arguments supplied to `exercise.checker`.
 
 <table>
@@ -397,9 +400,9 @@ See the table below for a full description of all the arguments supplied to `exe
 
 By default exercises are displayed with caption of "Code". However, in some cases you may want either a custom per-chunk caption or a generic caption with a different connotation (e.g. "Exercise" or "Sandbox"). For example:
 
-<div id="exercisecaption"></div>
-<script type="text/javascript">loadSnippet('exercisecaption')</script>
-
+```{r snippet-exercisecaption, echo = FALSE}
+insert_snippet("exercisecaption")
+```
 ## Code Assistance
 
 By default, code completions are automatically provided as users type within the exercise editor:
@@ -408,9 +411,9 @@ By default, code completions are automatically provided as users type within the
 
 You can optionally disable code completion (either globally or on a per-chunk basis) using the `exercise.completion` option. For example, the following illustrates turning off completions globally then enabling them for an individual chunk:
 
-<div id="exercisecompletion"></div>
-<script type="text/javascript">loadSnippet('exercisecompletion')</script>
-
+```{r snippet-exercisecompletion, echo = FALSE}
+insert_snippet("exercisecompletion")
+```
 Similarily, simple code diagnostics can also be provided, to inform users of errors in the R code written in exercise editors. Diagnostics can be controlled (either globally or on a per-chunk basis) using the `exercise.diagnostics` option.
 
 ## Editor Size
@@ -419,16 +422,16 @@ By default, the size of the exercise editor provided to users will match the num
 
 You can also specify a number of lines explicitly using the `exercise.lines` chunk option (this can be done on a per-chunk or global basis). For example, the following chunk specifies that the exercise code editor should be 15 lines high:
 
-<div id="exerciselines"></div>
-<script type="text/javascript">loadSnippet('exerciselines')</script>
-
+```{r snippet-exerciselines, echo = FALSE}
+insert_snippet("exerciselines")
+```
 ## Time Limits
 
 To mediate the problem of code which takes longer than expected to run you can specify the `exercise.timelimit` chunk option or alternatively the global `tutorial.exercise.timelimit` option.
 
 The following demonstrates setting a 10 second time limit as a global option, document level option, and chunk level option:
 
-<div id="exercisetimelimit"></div>
-<script type="text/javascript">loadSnippet('exercisetimelimit')</script>
-
+```{r snippet-exercisetimelimit, echo = FALSE}
+insert_snippet("exercisetimelimit")
+```
 Since tutorials are a highly interactive format you should in general be designing exercises that take no longer than 5 or 10 seconds to execute. Correspondingly, the default value for `tutorial.exercise.timelimit` if not otherwise specified is 30 seconds.

--- a/vignettes/articles/learnr.Rmd
+++ b/vignettes/articles/learnr.Rmd
@@ -37,9 +37,10 @@ You can create a new `learnr::tutorial` document from a template via the **New R
 
 This is what the YAML metadata looks like for an Rmd file that uses the tutorial format:
 
-<div id="tutorialyaml"></div>
-<script type="text/javascript">loadSnippet('tutorialyaml', 'markdown')</script>
-
+```{r snippet-tutorialyaml, echo = FALSE}
+source("snippets.R")
+insert_snippet("tutorialyaml")
+```
 
 Note that tutorials aren't just the Rmd source file, rather they are directories that contain the Rmd source file as well as other supporting files (e.g. figures and other images). As a result the default behavior is to create new tutorials within their own directory.
 
@@ -47,9 +48,9 @@ Note that tutorials aren't just the Rmd source file, rather they are directories
 
 There is one other requirement related to R code chunks that contain exercises or quiz questions: they must have a unique chunk label. For example, this chunk is labeled `addition`:
 
-<div id="addition"></div>
-<script type="text/javascript">loadSnippet('addition')</script>
-
+```{r snippet-addition, echo = FALSE}
+insert_snippet("addition")
+```
 This requirement exists to ensure that a stable identifier is associated with each interactive component. This in turn makes it possible to save and restore user work as well as facilitates aggregation and reporting on responses.
 
 ### Running Tutorials
@@ -93,13 +94,13 @@ Exercises can include hints or solutions as well as custom checking code to prov
 
 ### Questions
 
-You can include one or more multiple-choice quiz questions within a tutorial to help verify that readers understand the concepts presented. Questions can either have a single or multiple correct answers. 
+You can include one or more multiple-choice quiz questions within a tutorial to help verify that readers understand the concepts presented. Questions can either have a single or multiple correct answers.
 
 Include a question by calling the `question` function within an R code chunk:
 
-<div id="question"></div>
-<script type="text/javascript">loadSnippet('question')</script>
-
+```{r snippet-question, echo = FALSE}
+insert_snippet("question")
+```
 Here's what the above question would look like within a tutorial:
 
 <img src="images/question.png" width=729 height=227>
@@ -110,27 +111,27 @@ The [Questions](questions.html) page includes additional information on using qu
 
 You can include videos published on either [YouTube](https://www.youtube.com) or [Vimeo](https://vimeo.com) within a tutorial using the standard markdown image syntax. Note that any valid YouTube or Vimeo URL will work. For example, the following are all valid examples of video embedding:
 
-<div id="tutorvideos"></div>
-<script type="text/javascript">loadSnippet('tutorvideos', 'markdown')</script>
-
+```{r snippet-tutorvideos, echo = FALSE}
+insert_snippet("tutorvideos")
+```
 #### Video Size
 
 Videos are responsively displayed at 100% of their container's width (with height automatically determined based on a 16x9 aspect ratio). You can change this behavior by adding attributes to the markdown where you reference the video.
 
 You can specify an alternate percentage for the video's width or an alternate fixed width and height. For example:
 
-<div id="videos-size"></div>
-<script type="text/javascript">loadSnippet('videos-size', 'markdown')</script>
-
+```{r snippet-videos-size, echo = FALSE}
+insert_snippet("videos-size")
+```
 ### Shiny Components
 
-The **learnr** package uses `runtime: shiny_prerendered` to turn regular R Markdown documents into live tutorials. Since tutorials are Shiny applications at their core, it's also possible to add other forms of interactivity using Shiny (e.g. for teaching a statistical concept interactively). 
+The **learnr** package uses `runtime: shiny_prerendered` to turn regular R Markdown documents into live tutorials. Since tutorials are Shiny applications at their core, it's also possible to add other forms of interactivity using Shiny (e.g. for teaching a statistical concept interactively).
 
 The basic technique is to add a `context="server"` attribute to code chunks that are part of the Shiny server as opposed to UI definition. For example:
 
-<div id="shiny"></div>
-<script type="text/javascript">loadSnippet('shiny')</script>
-
+```{r snippet-shiny, echo = FALSE}
+insert_snippet("shiny")
+```
 You can learn more by reading the [Prerendered Shiny Documents](http://rmarkdown.rstudio.com/authoring_shiny_prerendered.html) article on the R Markdown website.
 
 
@@ -175,22 +176,22 @@ Tutorials store the various pieces of work done within them (exercise input and 
 
 One thing to keep in mind about preserved work is that if your tutorial changes significantly then the work restored may no longer match up well with the contents of your tutorial! (e.g. the nature and content of exercises and/or questions may have changed).
 
-Tutorial work is restored using the R chunk label of a given exercise or question, so if a chunk changes significantly you can invalidate the stored work by changing the chunk label. 
+Tutorial work is restored using the R chunk label of a given exercise or question, so if a chunk changes significantly you can invalidate the stored work by changing the chunk label.
 
 #### Tutorial Identifiers
 
 You can also invalidate stored work by changing the ID or version of your tutorial. If you publish tutorials within R packages then the version is automatically derived from the version of the package. You can also explicitly set the ID and version of a tutorial using YAML metadata, for example:
 
-<div id="tutoryamlids"></div>
-<script type="text/javascript">loadSnippet('tutoryamlids', 'markdown')</script>
-
+```{r snippet-tutoryamlids, echo = FALSE}
+insert_snippet("tutoryamlids")
+```
 Note that we use a reversed domain name for the tutorial id (`com.example.tutorials.my-first-tutorial`). This is to ensure that it is globally unique when deployed on a server with other tutorials. You could also choose to use a Universally Unique Identifier (UUID) created using the [**uuid**](https://cran.rstudio.com/web/packages/uuid/index.html) package.
 
 When you change the ID or version of a tutorial all stored work associated with the tutorial is invalidated and users of the tutorial will start fresh when accessing it again. It's therefore good practice to change the version whenever you make significant modifications to the exercises and questions within a tutorial (again, this occurs automatically for tutorials within R packages so long as the version of the R package is changed).
 
 ## Publishing
 
-Tutorials can be published all of the same ways that Shiny applications can, including running locally on an end-user's machine or running on a Shiny Server or hosting service like shinyapps.io. 
+Tutorials can be published all of the same ways that Shiny applications can, including running locally on an end-user's machine or running on a Shiny Server or hosting service like shinyapps.io.
 
 The most straightforward way to deploy a tutorial is to include it within an [R package](publishing.html#r-package) and have users run it directly via the `learnr::run_tutorial` function.
 

--- a/vignettes/articles/publishing.Rmd
+++ b/vignettes/articles/publishing.Rmd
@@ -118,9 +118,10 @@ Hosting services will typically want to provide a custom implementation for the 
 
 A custom storage provider is specified by assigning an R list which includes the storage functions to the `tutorial.storage` global option. For example, here is a "no-op" storage provider:
 
-<div id="tutorstorage"></div>
-<script type="text/javascript">loadSnippet('tutorstorage')</script>
-
+```{r snippet-tutorstorage, echo = FALSE}
+source("snippets.R")
+insert_snippet("tutorstorage")
+```
 The parameters passed to the storage provider's functions are as follows (note that the various ID fields can be customized by a hosting provider, see the [Tutorial Identifiers] section below for details):
 
 <table>
@@ -223,9 +224,9 @@ The event system can also be used to cause arbitrary code to run when the events
 
 You can capture events by using a custom event recorder function. This function is specified via the `tutorial.event_recorder` global option. For example, here's how you would define a simple event recorder function that prints to stdout:
 
-<div id="tutorrecorder"></div>
-<script type="text/javascript">loadSnippet('tutorrecorder')</script>
-
+```{r snippet-tutorrecorder, echo = FALSE}
+insert_snippet("tutorrecorder")
+```
 The following parameters are passed to the event recorder function (note that the various ID fields can be customized by a hosting provider, see the [Tutorial Identifiers] section below for details):
 
 <table>
@@ -402,14 +403,14 @@ The default tutorial and user identifiers are determined as follows:
 
 In addition, tutorial authors can use YAML metadata to provide custom tutorial IDs and versions. For example:
 
-<div id="tutoryamlids"></div>
-<script type="text/javascript">loadSnippet('tutoryamlids')</script>
-
+```{r snippet-tutoryamlids, echo = FALSE}
+insert_snippet("tutoryamlids")
+```
 #### Custom Identifiers
 
 Tutorial hosting services will very often need to provide custom external definitions for tutorial IDs/versions and user IDs. This can be accomplished by adding HTTP headers to the requests that route to the tutorial. The names of the headers are configurable, and should be specified using the `tutorial.http_header_tutorial_id`, `tutorial.http_header_tutorial_version` and `tutorial.http_header_user_id` global options. For example:
 
-<div id="tutorids"></div>
-<script type="text/javascript">loadSnippet('tutorids')</script>
-
+```{r snippet-tutorids, echo = FALSE}
+insert_snippet("tutorids")
+```
 Once configuring these custom header names you'd then need to ensure that the HTTP proxy layer mediating traffic to tutorials set them to the appropriate values.

--- a/vignettes/articles/publishing.Rmd
+++ b/vignettes/articles/publishing.Rmd
@@ -176,8 +176,9 @@ Using this method you can apply time limits, resource limits, and filesystem lim
 
 3. Define `onstart` and `oncleaup` hooks by setting the `tutorial.exercise.evaluator.onstart` and `tutorial.exercise.evaluator.oncleanup` global options. For example:
 
-    <div id="exerciseevaluator"></div>
-    <script type="text/javascript">loadSnippet('exerciseevaluator')</script>
+    ```{r snippet-exerciseevaluator, echo = FALSE}
+    insert_snippet("exerciseevaluator")
+    ```
 
 You'd likely set these options within `Rprofile.site` or another R source file that is evaluated prior to running the tutorial with `rmarkdown::run`.
 

--- a/vignettes/articles/questions.Rmd
+++ b/vignettes/articles/questions.Rmd
@@ -1,24 +1,25 @@
 ---
 title: "Interactive Questions"
 description: >
-  Create multiple choice questions or open-ended text-based questions or quizes 
+  Create multiple choice questions or open-ended text-based questions or quizes
   in your learnr tutorials.
 ---
 
 ## Overview
 
-You can include one or more multiple-choice quiz questions within a tutorial to help verify that readers understand the concepts presented. Questions can either have a single or multiple correct answers. 
+You can include one or more multiple-choice quiz questions within a tutorial to help verify that readers understand the concepts presented. Questions can either have a single or multiple correct answers.
 
 Include a question by calling the `question` function within an R code chunk:
 
-<div id="question"></div>
-<script type="text/javascript">loadSnippet('question')</script>
-
+```{r snippet-question, echo = FALSE}
+source("snippets.R")
+insert_snippet("question")
+```
 The above example defines a question with a single correct answer. You can also create questions that require multiple answers to be specified:
 
-<div id="questionmultiple"></div>
-<script type="text/javascript">loadSnippet('questionmultiple')</script>
-
+```{r snippet-questionmultiple, echo = FALSE}
+insert_snippet("questionmultiple")
+```
 Note that for the examples above we specify the `echo = FALSE` option on the R code chunks that produce the questions. This is required to ensure that the R source code for the questions is not printed within the document.
 
 This is what the above example quiz questions would look like within a tutorial:
@@ -29,18 +30,18 @@ This is what the above example quiz questions would look like within a tutorial:
 
 You can add answer-specific correct/incorrect messages using the `message` option. For example:
 
-<div id="questionmessages"></div>
-<script type="text/javascript">loadSnippet('questionmessages')</script>
-
+```{r snippet-questionmessages, echo = FALSE}
+insert_snippet("questionmessages")
+```
 <img src="images/questions-message.png" width=730 height=254>
 
 ## Formatting and Math
 
 You can use markdown to format text within questions, answers, and custom messages. You can also include embedded LaTeX math using the `$` delimiter. For example:
 
-<div id="questionmath"></div>
-<script type="text/javascript">loadSnippet('questionmath')</script>
-
+```{r snippet-questionmath, echo = FALSE}
+insert_snippet("questionmath")
+```
 Note the use of a double-backslash (`\\`) as the prefix for LaTeX macros. This is necessary to "escape" the single-backslash so that R doesn't interpret it as a special character. Here's what this example would look like within a tutorial:
 
 <img src="images/question-math.png" width=732 height=262>
@@ -50,20 +51,21 @@ Note the use of a double-backslash (`\\`) as the prefix for LaTeX macros. This i
 
 By default when an incorrect answer is provided users get the appropriate feedback and the correct answer(s) are highlighted. You can also provide an option for the user to try the question again. You can do this using the `allow_retry` option, for example:
 
-<div id="questionretry"></div>
-<script type="text/javascript">loadSnippet('questionretry')</script>
-
+```{r snippet-questionretry, echo = FALSE}
+insert_snippet("questionretry")
+```
 
 ## Random Answer Order
 
 If you want the answers to questions to be randomly arranged, you can add the `random_answer_order` option. For example:
 
-<div id="questionrandom"></div>
-<script type="text/javascript">loadSnippet('questionrandom')</script>
-
+```{r snippet-questionrandom, echo = FALSE}
+insert_snippet("questionrandom")
+```
 ## Groups of Questions
 
 You can present a group of related questions as a quiz by wrapping your questions within the `quiz` function. For example:
 
-<div id="questionquiz"></div>
-<script type="text/javascript">loadSnippet('questionquiz')</script>
+```{r snippet-questionquiz, echo = FALSE}
+insert_snippet("questionquiz")
+```

--- a/vignettes/articles/snippets.R
+++ b/vignettes/articles/snippets.R
@@ -1,0 +1,18 @@
+insert_snippet <- function(key) {
+  # <div id="exerciseeval"></div>
+  # <script type="text/javascript">loadSnippet('exerciseeval')</script>
+  snippet <- readLines(fs::path("../../pkgdown/assets/snippets", key, ext = "md"), warn = FALSE)
+  snippet <- paste(snippet, collapse = "\n")
+  snippet <- gsub("`", "&#96;", snippet)
+  snippet <- htmltools::HTML(snippet)
+
+  htmltools::withTags(
+    htmltools::tagList(
+      div(
+        id = key,
+        pre(class = "markdown", code(snippet)),
+      ),
+      script(type = "text/javascript", htmltools::HTML(sprintf("loadSnippet('%s')", key)))
+    )
+  )
+}

--- a/vignettes/articles/snippets.R
+++ b/vignettes/articles/snippets.R
@@ -10,6 +10,7 @@ insert_snippet <- function(key) {
     htmltools::tagList(
       div(
         id = key,
+        class = "sourceCode",
         pre(class = "markdown", code(snippet)),
       ),
       script(type = "text/javascript", htmltools::HTML(sprintf("loadSnippet('%s')", key)))


### PR DESCRIPTION
Improves the accessibility and use of snippets in the documentation, primarily in two ways:

1. We now write the snippet into the static HTML of the documentation page. The code blocks will be overwritten by the ace editor, but if for any reason the editor fails to load, the page will appear identical to other documentation that doesn't use the Ace editor.

2. When loading the editor, we keep that code block (actually we re-write it) but add `.sr-only` so that it's available for screen readers. My understanding (and testing shows) that screen readers will move over the Ace editor. Ideally, the hidden code block will be announced as if the Ace editor weren't present.