### PR TITLE
Improve keyboard navigation around exercise component

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,8 +54,6 @@
 
 -   Authors can choose to reveal (default) or hide the solution to an exercise. Set `exercise.reveal_solution` in the chunk options of a `*-solution` chunk to choose whether or not the solution is revealed to the user. The option can also be set globally with `tutorial_options()`. In a future version of learnr, the default will likely be changed to hide solutions (#402).
 
--   Feedback messages can now be an `htmltools::tag()`, `htmltools::tagList()`, or a character message (#458) (#458)
-
 -   Keyboard navigation and keyboard shortcuts for the interactive exercise code editor have been improved:
 
     -   To avoid trapping keyboard focus and to allow users to navigate through a tutorial with the keyboard, pressing <kbd>Esc</kbd> in an interactive exercise code editor now temporarily disables the use of <kbd>Tab</kbd> for indenting, making it possible for users to move to the next or previous element in the tutorial (#652).
@@ -69,6 +67,8 @@
     -   Hitting the TAB key in an exercise has always opened the auto-completion drop down. Now, hitting the TAB key will also complete the currently selected code completion (#428).
 
 -   The native R pipe, introduced in R 4.1, is now recognized as a valid R operator in the interactive exercise editor (thanks @ijlyttle, #595).
+
+-   Feedback messages can now be an `htmltools::tag()`, `htmltools::tagList()`, or a character message (#458).
 
 -   We no longer display an invisible exercise result warning automatically. Instead, authors must set the exercise chunk option exercise.warn_invisible = TRUE to display an invisible result warning message (@nischalshrestha #373).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,13 +56,17 @@
 
 -   Feedback messages can now be an `htmltools::tag()`, `htmltools::tagList()`, or a character message (#458) (#458)
 
--   Interactive exercises now know the RStudio shortcuts for the pipe (`%>%`) (Command/Control + Shift + M) and assignment (`<-`) (Alt + -) operators in exercise code boxes (#472).
+-   Keyboard navigation and keyboard shortcuts for the interactive exercise code editor have been improved:
 
--   Clicking **Run Code** or using the keyboard shortcut (Cmd/Ctrl + Enter) now runs the selected code only, if any code is selected (thanks @petzi53 #512, #514).
+    -   To avoid trapping keyboard focus and to allow users to navigate through a tutorial with the keyboard, pressing <kbd>Esc</kbd> in an interactive exercise code editor now temporarily disables the use of <kbd>Tab</kbd> for indenting, making it possible for users to move to the next or previous element in the tutorial (#652).
 
--   Commented code within an exercise is no longer be auto completed (#604).
+    -   Interactive exercises now know the RStudio shortcuts for the pipe (`%>%`) (Command/Control + Shift + M) and assignment (`<-`) (Alt + -) operators in exercise code boxes (#472).
 
--   Hitting the TAB key in an exercise has always opened the auto-completion drop down. Now, hitting the TAB key will also complete the currently selected code completion (#428).
+    -   Clicking **Run Code** or using the keyboard shortcut (Cmd/Ctrl + Enter) now runs the selected code only, if any code is selected (thanks @petzi53 #512, #514).
+
+    -   Commented code within an exercise is no longer be auto completed (#604).
+
+    -   Hitting the TAB key in an exercise has always opened the auto-completion drop down. Now, hitting the TAB key will also complete the currently selected code completion (#428).
 
 -   The native R pipe, introduced in R 4.1, is now recognized as a valid R operator in the interactive exercise editor (thanks @ijlyttle, #595).
 

--- a/R/auto-complete.R
+++ b/R/auto-complete.R
@@ -9,7 +9,7 @@ auto_complete_r <- function(line, label = NULL, server_env = NULL) {
   # completion settings below ensures completions aren't returned if the last
   # line is part of a multi-line quote.
   last_line <- utils::tail(strsplit(line, "\n")[[1]], 1)
-  if (detect_comment(last_line)) {
+  if (length(last_line) == 0 || detect_comment(last_line)) {
     # If a comment is found, return `list()` to signify no completions are found
     # (Similar to the output of Map(list, list()))
     return(list())

--- a/inst/lib/tutorial/tutorial-autocompletion.js
+++ b/inst/lib/tutorial/tutorial-autocompletion.js
@@ -201,11 +201,23 @@ function TutorialCompleter(tutorial) {
 
     const keys = new KeyCombination(event);
 
-    if (!(keys.keyCode === KEYCODE_TAB && editor.container.matches('.ace_indent_off'))) {
-      // manually handle event, except when tabbing away from editor
-      event.stopPropagation();
-      event.preventDefault();
+    if (keys.keyCode === KEYCODE_TAB) {
+      // don't autocomplete when tabbing away from editor
+      if (editor.container.matches('.ace_indent_off')) {
+        return;
+      }
+
+      // check that we're not at the start of the line
+      const pos = editor.getCursorPosition();
+      const line = editor.session.getLine(pos.row);
+      const isCursorAtStart = line.substr(0, pos.column).trim() === "";
+      if (isCursorAtStart) {
+       return;
+      }
     }
+
+    event.stopPropagation();
+    event.preventDefault();
     editor.execCommand("startAutocomplete");
   };
 

--- a/inst/lib/tutorial/tutorial-autocompletion.js
+++ b/inst/lib/tutorial/tutorial-autocompletion.js
@@ -199,9 +199,13 @@ function TutorialCompleter(tutorial) {
     // cancel any pending live autocompletion
     clearTimeout(editor.$autocompletionTimerId);
 
-    // manually handle event
-    event.stopPropagation();
-    event.preventDefault();
+    const keys = new KeyCombination(event);
+
+    if (!(keys.keyCode === KEYCODE_TAB && editor.container.matches('.ace_indent_off'))) {
+      // manually handle event, except when tabbing away from editor
+      event.stopPropagation();
+      event.preventDefault();
+    }
     editor.execCommand("startAutocomplete");
   };
 

--- a/inst/lib/tutorial/tutorial.css
+++ b/inst/lib/tutorial/tutorial.css
@@ -151,3 +151,11 @@
   width: 20px;
   margin-right: -9px; /* net 6px */
 }
+
+/* Add outline indicator when tab key can change focus
+   to the next or previous element. `.ace_indent_off` is
+   a class added by learnr when the tab key is disabled.
+*/
+.ace_indent_off.ace_focus {
+  outline: 1px solid currentColor;
+}

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -978,7 +978,7 @@ Tutorial.prototype.$initializeExerciseEditors = function() {
     var engine = chunk_options["engine"]
 
     if (engine.toLowerCase() != "r") {
-      // disable ace editor diagnostics if a non-r langauge engine is set
+      // disable ace editor diagnostics if a non-r language engine is set
       diagnostics = null;
       // disable auto-completion if a non-r language engine is set
       completion = null;
@@ -1035,7 +1035,32 @@ Tutorial.prototype.$initializeExerciseEditors = function() {
       editor.focus();
     });
 
-    // mange ace height as the document changes
+    // Allow users to escape the editor and move to next focusable element
+    const tabCommandKeys = {
+      indent: editor.commands.byName['indent'].bindKey,
+      outdent: editor.commands.byName['outdent'].bindKey
+    }
+
+    function toggleTabCommands(enable) {
+      ['indent', 'outdent'].forEach(function(name) {
+        const command = editor.commands.byName[name];
+        // turn off tab commands or restore original bindKey
+        command.bindKey = enable ? tabCommandKeys[name] : null;
+        editor.commands.addCommand(command);
+      });
+      // update class on editor to reflect tab command state
+      $(editor.container).toggleClass('ace_indent_off', !enable);
+    }
+
+    editor.on('focus', function() { toggleTabCommands(true); });
+
+    editor.commands.addCommand({
+      name: "escape",
+      bindKey: {win: "Esc", mac: "Esc"},
+      exec: function() { toggleTabCommands(false); }
+    });
+
+    // manage ace height as the document changes
     var updateAceHeight = function()  {
       var lines = exercise.attr('data-lines');
       if (lines && (lines > 0)) {
@@ -1313,7 +1338,7 @@ Tutorial.prototype.$addSolution = function(exercise, panel_heading, editor) {
 
 // remove a solution for an exercise
 Tutorial.prototype.$removeSolution = function(exercise) {
-  // destory clipboardjs object if we've got one
+  // destroy clipboardjs object if we've got one
   var solutionButton = exercise.find('.btn-tutorial-copy-solution');
   if (solutionButton.length > 0)
     solutionButton.data('clipboard').destroy();

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -1036,12 +1036,12 @@ Tutorial.prototype.$initializeExerciseEditors = function() {
     });
 
     // Allow users to escape the editor and move to next focusable element
-    const tabCommandKeys = {
-      indent: editor.commands.byName['indent'].bindKey,
-      outdent: editor.commands.byName['outdent'].bindKey
-    }
-
     function toggleTabCommands(enable) {
+      const tabCommandKeys = {
+        indent:  {win: 'Tab',       mac: 'Tab'},
+        outdent: {win: 'Shift+Tab', mac: 'Shift+Tab'}
+      };
+
       ['indent', 'outdent'].forEach(function(name) {
         const command = editor.commands.byName[name];
         // turn off tab commands or restore original bindKey

--- a/inst/lib/tutorial/tutorial.js
+++ b/inst/lib/tutorial/tutorial.js
@@ -913,9 +913,8 @@ Tutorial.prototype.$initializeExerciseEditors = function() {
 
     // function to add a submit button
     function add_submit_button(icon, style, text, check, datai18n) {
-      var button = $('<a class="btn ' + style + ' btn-xs btn-tutorial-run"></a>');
+      var button = $('<button class="btn ' + style + ' btn-xs btn-tutorial-run"></button>');
       button.append($('<i class="fa ' + icon + '"></i>'));
-      button.attr('type', 'button');
       button.append(' ' + '<span data-i18n="button.' + datai18n + '">' + text + '</span>')
       var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
       var title = text;
@@ -1105,8 +1104,7 @@ Tutorial.prototype.$addSolution = function(exercise, panel_heading, editor) {
 
   // function to add a helper button
   function addHelperButton(icon, caption, ele_class, datai18n) {
-    var button = $('<a class="btn btn-light btn-xs btn-tutorial-solution"></a>');
-    button.attr('role', 'button');
+    var button = $('<button class="btn btn-light btn-xs btn-tutorial-solution"></button>');
     button.attr('title', caption);
     button.attr('data-i18n', '');
     button.addClass(ele_class);
@@ -1252,7 +1250,7 @@ Tutorial.prototype.$addSolution = function(exercise, panel_heading, editor) {
 
           // add next hint button if we have > 1 hint
           if (solution === null && hints.length > 1) {
-            var nextHintButton = $('<a class="btn btn-light btn-xs btn-tutorial-next-hint"></a>');
+            var nextHintButton = $('<button class="btn btn-light btn-xs btn-tutorial-next-hint"></button>');
             nextHintButton.append($('<span data-i18n="button.hintnext">Next Hint</span>'));
             nextHintButton.append(' ');
             nextHintButton.append($('<i class="fa fa-angle-double-right"></i>'));
@@ -1269,8 +1267,8 @@ Tutorial.prototype.$addSolution = function(exercise, panel_heading, editor) {
           }
 
           // add copy button
-          var copyButton = $('<a class="btn btn-info btn-xs ' +
-                             'btn-tutorial-copy-solution pull-right"></a>');
+          var copyButton = $('<button class="btn btn-info btn-xs ' +
+                             'btn-tutorial-copy-solution pull-right"></button>');
           copyButton.append($('<i class="fa fa-copy"></i>'));
           copyButton.append(' ')
           copyButton.append($('<span data-i18n="button.copyclipboard">Copy to Clipboard</span>'));


### PR DESCRIPTION
Currently, the exercise component traps keyboard focus when a user enters the code editor. The goal of this PR is to alleviate this problem by allowing users to press <kbd>Esc</kbd> to turn off the use of the <kbd>Tab</kbd> key for indent and outdent behavior. We also add an outline to the editor element when in this mode to visually indicate that focus has been "given back" to the container. Note that indent/outdent via <kbd>Ctrl</kbd> + <kbd>]</kbd>/<kbd>[</kbd> will still work in this mode.

Additionally, I replaced the use of anchor elements with class `btn` in the exercise toolbar with `<button>` elements. This automatically allows those buttons to receive keyboard focus as well.

Finally, a small change was needed in the autocomplete logic to ensure that the <kbd>Tab</kbd> events aren't trapped when they're intended to move focus out of the exercise element. In this process, a small bug with the autocompletion on empty code was revealed: we no longer will try to return autocomplete suggestions on an empty line.

For #636

Here's a screen recording showing the new behavior. I added a red focus outline to make it more obvious which object has focus.

1. Tabbing in the tutorial moves through the exercise buttons — Start Over, Run Code — and then into the exercise editor.
2. Here, <kbd>Tab</kbd> inserts an indent when pressed at the start of the line and <kbd>Shift</kbd> + <kbd>Tab</kbd> inserts an outdent.
3. When code has been written on the line, <kbd>Tab</kbd> opens autocomplete.
4. Pressing <kbd>Esc</kbd> disables indent/outdent via <kbd>Tab</kbd>, allowing the user to move focus to the next or previous element.
5. Users can also trigger the button behavior using the keyboard for both Start Over and Run Code.

https://user-images.githubusercontent.com/5420529/151831501-7059f87b-8ea8-4c9f-bbcb-d6ebdb6fc494.mp4