### PR TITLE
Parse error receive "parse_error" class

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -890,9 +890,12 @@ exercise_check_code_for_blanks <- function(exercise) {
 
 exercise_check_code_is_parsable <- function(exercise) {
   error <- rlang::catch_cnd(parse(text = exercise$code), "error")
-  if (is.null(error)) {
+  if (!inherits(error, "error")) {
     return(NULL)
   }
+
+  # Make "parse_error"s identifiable in the error checker
+  class(error) <- c("parse_error", class(error))
 
   # apply the error checker (if explicitly provided) to the parse error
   if (nzchar(exercise$error_check %||% "")) {

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -995,7 +995,7 @@ test_that("default message if exercise.blanks is FALSE", {
 # Unparsable Code ---------------------------------------------------------
 
 test_that("evaluate_exercise() returns a message if code is unparsable", {
-  ex     <- mock_exercise(user_code = 'print("test"')
+  ex <- mock_exercise(user_code = 'print("test"')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
@@ -1005,7 +1005,7 @@ test_that("evaluate_exercise() returns a message if code is unparsable", {
   )
   expect_match(result$error_message, "unexpected end of input")
 
-  ex     <- mock_exercise(user_code = 'print("test)')
+  ex <- mock_exercise(user_code = 'print("test)')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
@@ -1015,7 +1015,7 @@ test_that("evaluate_exercise() returns a message if code is unparsable", {
   )
   expect_match(result$error_message, "unexpected INCOMPLETE_STRING")
 
-  ex     <- mock_exercise(user_code = 'mean(1:10 na.rm = TRUE)')
+  ex <- mock_exercise(user_code = 'mean(1:10 na.rm = TRUE)')
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
   expect_match(result$feedback$message, "text.unparsable")
@@ -1040,6 +1040,12 @@ test_that("evaluate_exercise() passes parse error to explicit exercise checker f
   ex$error_check <- NULL
   res <- evaluate_exercise(ex, new.env())
   expect_equal(res$feedback, exercise_check_code_is_parsable(ex)$feedback)
+})
+
+test_that("exericse_check_code_is_parsable() gives error checker a 'parse_error' condition", {
+  ex <- mock_exercise(user_code = 'print("test"', error_check = I("last_value"))
+  result <- evaluate_exercise(ex, new.env())
+  expect_s3_class(result$feedback$checker_result, class = c("parse_error", "condition"))
 })
 
 test_that("Errors with global setup code result in an internal error", {


### PR DESCRIPTION
Adds a `"parse_error"` class to the error thrown when trying to parse the user's submitted code. This makes it possible for the error checker — which now gets first dibs on the parse error before the default parse error feedback is returned — to differentiate between parse errors and other errors.

```r
# in "base" learnr error checking code
inherits(last_value, "parse_error")

# in gradethis error checking code
inherits(.result, "parse_error")
```