### PR TITLE
Unexpected `render_exercise()` errors are now internal errors

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -419,6 +419,12 @@ evaluate_exercise <- function(
   rmd_results <- tryCatch(
     render_exercise(exercise, envir),
     error = function(err_render) {
+      if (!inherits(err_render, "learnr_render_exercise_error")) {
+        # render exercise errors are expected, but something really went wrong
+        return(
+          exercise_result_error_internal(exercise, err_render, "evaluating your exercise", "inside render_exercise()")
+        )
+      }
       error_feedback <- NULL
       error_check_code <- exercise$error_check
       error_should_check <- nzchar(exercise$check) || nzchar(exercise$code_check)

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -260,6 +260,20 @@ test_that("evaluate_exercise() returns an internal error for global setup chunk 
   expect_s3_class(res$feedback$error, "simpleError")
 })
 
+test_that("evaluate_exercise() returns an internal error when `render_exercise()` fails", {
+  local_edition(2)
+  with_mock(
+    "learnr:::render_exercise" = function(...) stop("render error"),
+    expect_warning(
+      res <- evaluate_exercise(mock_exercise(), new.env())
+    )
+  )
+
+  expect_match(res$feedback$message, "evaluating your exercise")
+  expect_s3_class(res$feedback$error, "simpleError")
+  expect_equal(conditionMessage(res$feedback$error), "render error")
+})
+
 test_that("render_exercise() cleans up exercise_prep files", {
   skip_if_not_pandoc("1.14")
 


### PR DESCRIPTION
Previously, when `render_exercise()` returns an error, we assumed it was an error created and handled in the `tryCatch()` inside `render_exercise()` around the user's code evaluation. But it's possible (a slim possibility) that `render_exercise()` might fail before we enter the `tryCatch()`.

The fix is relatively simple: we now check if we have an expected error and if not we raise an internal error.