### PR TITLE
Throw render error with underlying error as `parent`

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -449,10 +449,13 @@ evaluate_exercise <- function(
           envir_result = err_render$envir_result,
           evaluate_result = err_render$evaluate_result,
           envir_prep = err_render$envir_prep,
-          last_value = err_render$last_value
+          last_value = err_render$parent
         )
       }
-      exercise_result_error(err_render$error_message, error_feedback$feedback)
+      exercise_result_error(
+        error_message = conditionMessage(err_render$parent),
+        feedback = error_feedback$feedback
+      )
     }
   )
 
@@ -720,8 +723,7 @@ render_exercise <- function(exercise, envir) {
       envir_result = envir_result,
       evaluate_result = evaluate_result,
       envir_prep = envir_prep,
-      last_value = e,
-      error_message = msg
+      parent = e
     )
   })
 

--- a/tests/testthat/_snaps/exercise.md
+++ b/tests/testthat/_snaps/exercise.md
@@ -60,19 +60,6 @@
       get("___sql_result")
       ```
 
----
-
-    Code
-      writeLines(res_sql_engine$html_output)
-    Output
-      
-      
-      
-      <pre><code>  mpg cyl disp  hp drat    wt  qsec vs am gear carb
-      1  21   6  160 110  3.9 2.620 16.46  0  1    4    4
-      2  21   6  160 110  3.9 2.875 17.02  0  1    4    4
-       [ reached &#39;max&#39; / getOption(&quot;max.print&quot;) -- omitted 30 rows ]</code></pre>
-
 # SQL exercises - with explicit `output.var`
 
     Code
@@ -94,17 +81,4 @@
       ```{r eval=exists("___sql_result")}
       get("___sql_result")
       ```
-
----
-
-    Code
-      writeLines(format(res_sql_engine$html_output))
-    Output
-      
-      
-      
-      <pre><code>  mpg cyl disp  hp drat    wt  qsec vs am gear carb
-      1  21   6  160 110  3.9 2.620 16.46  0  1    4    4
-      2  21   6  160 110  3.9 2.875 17.02  0  1    4    4
-       [ reached &#39;max&#39; / getOption(&quot;max.print&quot;) -- omitted 30 rows ]</code></pre>
 

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -125,8 +125,8 @@ test_that("render_exercise() returns envir_result up to error", {
     )
   )
 
-  expect_s3_class(exercise_result$last_value, "simpleError")
-  expect_equal(conditionMessage(exercise_result$last_value), "boom")
+  expect_s3_class(exercise_result$parent, "simpleError")
+  expect_equal(conditionMessage(exercise_result$parent), "boom")
 
   expect_false(
     identical(exercise_result$envir_prep, exercise_result$envir_result)


### PR DESCRIPTION
The goal here was to avoid a failure on Windows. I'm not sure if this PR directly fixes that error or if it just resolved on its own...

But this is still a good idea, since it aligns better with the intended usage of `rlang::abort()`. In short, we catch and rethrow render errors from `render_exercise()` that need to be handled in `evaluate_exercise()`. There, we may want to extract information from the original error, and we now put that in the usual place of `$parent`.