### PR TITLE
Allow whitespace after code headers in `split_code_headers()`

### DIFF
--- a/R/staticimports.R
+++ b/R/staticimports.R
@@ -19,7 +19,11 @@ is_html_tag <- function(x) {
   inherits(x, c("shiny.tag", "shiny.tag.list"))
 }
 
-knitr_engine_caption <- function(engine) {
+knitr_engine_caption <- function(engine = NULL) {
+  if (is.null(engine)) {
+    engine <- "r"
+  }
+
   switch(
     tolower(engine),
     "bash" = "Bash",
@@ -60,7 +64,7 @@ split_code_headers <- function(code, prefix = "section") {
   code <- str_trim(code, character = "[\r\n]")
   code <- strsplit(code, "\n")[[1]]
 
-  rgx_header <- "^(#+)([ -]*)(.+?)?\\s*----+$"
+  rgx_header <- "^\\s*(#+)([ -]*)(.+?)?\\s*----+\\s*$"
   headers <- regmatches(code, regexec(rgx_header, code, perl = TRUE))
   lines_headers <- which(vapply(headers, length, integer(1)) > 0)
 

--- a/inst/staticexports/split_code_headers.R
+++ b/inst/staticexports/split_code_headers.R
@@ -7,7 +7,7 @@ split_code_headers <- function(code, prefix = "section") {
   code <- str_trim(code, character = "[\r\n]")
   code <- strsplit(code, "\n")[[1]]
 
-  rgx_header <- "^(#+)([ -]*)(.+?)?\\s*----+$"
+  rgx_header <- "^\\s*(#+)([ -]*)(.+?)?\\s*----+\\s*$"
   headers <- regmatches(code, regexec(rgx_header, code, perl = TRUE))
   lines_headers <- which(vapply(headers, length, integer(1)) > 0)
 

--- a/inst/staticexports/split_code_headers.R
+++ b/inst/staticexports/split_code_headers.R
@@ -7,7 +7,7 @@ split_code_headers <- function(code, prefix = "section") {
   code <- str_trim(code, character = "[\r\n]")
   code <- strsplit(code, "\n")[[1]]
 
-  rgx_header <- "^\\s*(#+)([ -]*)(.+?)?\\s*----+\\s*$"
+  rgx_header <- "^(#+)([ -]*)(.+?)?\\s*----+\\s*$"
   headers <- regmatches(code, regexec(rgx_header, code, perl = TRUE))
   lines_headers <- which(vapply(headers, length, integer(1)) > 0)
 

--- a/tests/testthat/test-staticimports.R
+++ b/tests/testthat/test-staticimports.R
@@ -34,15 +34,4 @@ test_that("split_code_headers()", {
     ),
   target
 )
-
-  # Indented
-  expect_equal(
-    split_code_headers(
-      "# one ----
-      1
-      # two ----
-      2"
-    ),
-    list(one = "      1", two = "      2")
-  )
 })

--- a/tests/testthat/test-staticimports.R
+++ b/tests/testthat/test-staticimports.R
@@ -1,0 +1,48 @@
+test_that("split_code_headers()", {
+  target <- list(one = "1", two = "2")
+
+  # No whitespace after dashes
+  expect_equal(
+    split_code_headers(
+"# one ----
+1
+# two ----
+2"
+    ),
+    target
+  )
+
+
+  # Whitespace after first header
+  expect_equal(
+    split_code_headers(
+"# one ----
+1
+# two ----
+2"
+    ),
+  target
+  )
+
+  # Whitespace after subsequent headers
+  expect_equal(
+    split_code_headers(
+"# one ----
+1
+# two ----
+2"
+    ),
+  target
+)
+
+  # Indented
+  expect_equal(
+    split_code_headers(
+      "# one ----
+      1
+      # two ----
+      2"
+    ),
+    list(one = "      1", two = "      2")
+  )
+})


### PR DESCRIPTION
There's no longer an issue if there is whitespace after first header

``` r
split_code_headers <- learnr:::split_code_headers

split_code_headers(
"# one ----  
1
# two ----
2"
)
#> $one
#> [1] "1"
#> 
#> $two
#> [1] "2"
```

or if there is whitespace after subsequent headers

``` r
split_code_headers(
"# one ----
1
# two ----  
2"
)
#> $one
#> [1] "1"
#> 
#> $two
#> [1] "2"
```

<sup>Created on 2022-03-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #677.