### PR TITLE
`get_tutorial_info()` returns complete exercsies

### DIFF
--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -383,6 +383,7 @@ tutorial_knitr_options <- function() {
 
         exercise_cache <- structure(
           list(
+            label = options[["label"]],
             global_setup = get_setup_global_exercise(),
             setup = all_setup_code,
             chunks = all_chunks,

--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -276,6 +276,20 @@ describe_tutorial_items <- function() {
     data = I(unname(tutorial_cache_env$objects))
   )
 
+  for (i in seq_along(items[["data"]])) {
+    if (items[["type"]][[i]] != "exercise") next
+
+    label <- items[["label"]][[i]]
+    code_chunks <- Filter(
+      x = items[["data"]][[i]][["chunks"]],
+      function(chunks) {
+        identical(chunks[["label"]], label)
+      }
+    )
+    items[["data"]][[i]][["code"]] <- standardize_code(code_chunks[[1]]$code)
+    items[["data"]][[i]][["version"]] <- current_exercise_version
+  }
+
   items <- as.data.frame(items, stringsAsFactors = FALSE)
   class(items$data) <- "list"
   items$order <- seq_len(nrow(items))

--- a/tests/testthat/test-tutorial-state.R
+++ b/tests/testthat/test-tutorial-state.R
@@ -31,7 +31,17 @@ test_that("tutorial_cache_works", {
   expect_named(info$items, c("order", "label", "type", "data"))
 
   all <- get_tutorial_cache()
-  expect_equal(info$items$data, unname(all))
+  for (i in seq_along(info$items$data)) {
+    item <- info$items$data[[i]]
+    label <- info$items$label[[i]]
+
+    if (inherits(item, "tutorial_exercise")) {
+      # these items are added by app or by `get_tutorial_info()`
+      item <- item[setdiff(names(item), c("code", "version"))]
+      class(item) <- "tutorial_exercise"
+    }
+    expect_equal(item, all[[label]])
+  }
 
   # tutorial cache lists items in order of appearance
   exercises <- c("two-plus-two", "add-function", "print-limit")


### PR DESCRIPTION
Makes it easier to use extracted exercises in `evaluate_exericse()` since all of the expected pieces are now included:

* `$label` is added in the knitr hooks
* `get_tutorial_info()` adds initial exercise code as `$code` 
* `get_tutorial_info()` adds current exercise version as `$version`

