### PR TITLE
Remove forced chunk options from exercise chunk

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1202,9 +1202,16 @@ prepare_exercise <- function(exercise) {
     forced = forced_opts_exercise
   )
 
+  discard_forced_opts <- function(opts) {
+    opts[setdiff(names(opts), names(forced_opts_exercise))]
+  }
+
   exercise$chunks <- lapply(exercise[["chunks"]], function(chunk) {
+
     if (identical(chunk[["label"]], exercise[["label"]])) {
       # Exercise Chunk ----
+      chunk[["opts"]] <- discard_forced_opts(chunk[["opts"]])
+
       chunk[["opts"]] <- merge_chunk_options(
         chunk = chunk[["opts"]],
         inherited = I(exercise[["opts_chunk"]])

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -1354,3 +1354,25 @@ test_that("SQL exercises - with explicit `output.var`", {
 
   DBI::dbDisconnect(con)
 })
+
+
+# prepare_exercise() ------------------------------------------------------
+
+test_that("prepare_exercise() removes forced default chunk options from exercise chunk", {
+  ex <- mock_exercise(
+    label = "ex",
+    chunks = list(
+      mock_chunk("ex", "1 + 1", exercise = TRUE, eval = FALSE)
+    ),
+    check = TRUE
+  )
+
+  # `eval = FALSE` is set on the exercise chunk option
+  expect_false(ex$chunks[[1]]$opts$eval)
+
+  # but `prepare_exercise()` removes that option
+  expect_null(prepare_exercise(ex)$chunks[[1]]$opts$eval)
+
+  res <- evaluate_exercise(ex, new.env())
+  expect_equal(res$feedback$checker_args$last_value, 2)
+})


### PR DESCRIPTION
Fixes #696

Exercise chunk options that are set globally in the exercise rmd aren't allowed to appear in the exercise chunk used in the rmd. (I'm being vague because this is very deep in the internals and not user-visible.)