### PR TITLE
Improve external evaluators result handling

### DIFF
--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -251,7 +251,12 @@ internal_external_evaluator <- function(
                 event_trigger(session, "external_evaluator_result", r)
               }
 
-              result <<- p
+              valid_json <- jsonlite::validate(r)
+              if (!valid_json) {
+                stop(attr(valid_json, "err"))
+              }
+
+              result <<- r
             }, error = function(e){
               print(e)
               fail_cb(response_to_error(res))

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -321,7 +321,7 @@ internal_external_evaluator <- function(
           if (length(result) > 1) {
             result <- paste(result, collapse = "\n")
           }
-          external_evaluator_result_from_json(result)
+          exercise_result_from_json(result)
         }, error = function(e) {
           exercise_result_error_internal(
             exercise = exercise,
@@ -334,7 +334,7 @@ internal_external_evaluator <- function(
   }
 }
 
-external_evaluator_result_to_json <- function(result) {
+exercise_result_to_json <- function(result) {
   stringify_html <- function(result) {
     if (inherits(result, c("shiny.tag", "shiny.tag.list", "html"))) {
       return(format(result))
@@ -353,7 +353,7 @@ external_evaluator_result_to_json <- function(result) {
   jsonlite::toJSON(result, auto_unbox = TRUE, null = "null")
 }
 
-external_evaluator_result_from_json <- function(json) {
+exercise_result_from_json <- function(json) {
   result <- jsonlite::fromJSON(json, simplifyVector = FALSE)
 
   # Validate feedback and warn about problems, returning no feedback if there

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -314,7 +314,13 @@ internal_external_evaluator <- function(
       },
 
       result = function() {
+        if (is_exercise_result(result)) {
+          return(result)
+        }
         tryCatch({
+          if (length(result) > 1) {
+            result <- paste(result, collapse = "\n")
+          }
           external_evaluator_result_from_json(result)
         }, error = function(e) {
           exercise_result_error_internal(

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -251,8 +251,6 @@ internal_external_evaluator <- function(
                 event_trigger(session, "external_evaluator_result", r)
               }
 
-              p <- jsonlite::fromJSON(r)
-              p$html_output <- htmltools::HTML(p$html_output)
               result <<- p
             }, error = function(e){
               print(e)
@@ -312,14 +310,7 @@ internal_external_evaluator <- function(
 
       result = function() {
         tryCatch({
-          result$feedback <- tryCatch(
-            feedback_validated(result$feedback),
-            error = function(e) {
-              warning(e$message)
-              NULL
-            }
-          )
-          do.call(exercise_result, result)
+          external_evaluator_result_from_json(result)
         }, error = function(e) {
           exercise_result_error_internal(
             exercise = exercise,
@@ -330,6 +321,41 @@ internal_external_evaluator <- function(
       }
     )
   }
+}
+
+external_evaluator_result_to_json <- function(result) {
+  stringify_html <- function(result) {
+    if (inherits(result, c("shiny.tag", "shiny.tag.list", "html"))) {
+      return(format(result))
+    }
+    if (is.list(result)) {
+      result <- lapply(result, stringify_html)
+    }
+    result
+  }
+
+  result <- stringify_html(result)
+  if (!is.null(result$feedback)) {
+    result$feedback <- unclass(result$feedback)
+  }
+
+  jsonlite::toJSON(result, auto_unbox = TRUE, null = "null")
+}
+
+external_evaluator_result_from_json <- function(json) {
+  result <- jsonlite::fromJSON(json, simplifyVector = FALSE)
+
+  # Validate feedback and warn about problems, returning no feedback if there
+  # are problems rather than failing completely
+  result$feedback <- tryCatch(
+    feedback_validated(result$feedback),
+    error = function(e) {
+      warning(e$message)
+      NULL
+    }
+  )
+
+  do.call(exercise_result, result)
 }
 
 #' Returns a promise representing a a unique session

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1124,6 +1124,10 @@ exercise_result <- function(
     feedback$html <- feedback_as_html(feedback)
   }
 
+  if (is.character(html_output) && any(nzchar(html_output))) {
+    html_output <- htmltools::HTML(html_output)
+  }
+
   structure(
     list(
       feedback = feedback,

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1126,6 +1126,8 @@ exercise_result <- function(
 
   if (is.character(html_output) && any(nzchar(html_output))) {
     html_output <- htmltools::HTML(html_output)
+  } else if (length(html_output) == 0) {
+    html_output <- NULL
   }
 
   structure(

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -264,7 +264,7 @@ test_that("external_evaluator works", {
     headers = list(
       'Content-Type' = 'application/json'
     ),
-    body = external_evaluator_result_to_json(mockResult)
+    body = exercise_result_to_json(mockResult)
   )
 
   responses <- list(
@@ -345,7 +345,7 @@ test_that("bad statuses or invalid json are handled sanely", {
       headers = list(
         'Content-Type' = 'application/json'
       ),
-      body = external_evaluator_result_to_json(mockResult)
+      body = exercise_result_to_json(mockResult)
     ),
     `POST /learnr/invalidjson` = list(
       status = 200L,
@@ -433,9 +433,9 @@ test_that("external evaluator result roundtrip", {
   ex <- mock_exercise()
   res <- evaluate_exercise(ex, new.env())
 
-  res_json <- external_evaluator_result_to_json(res)
+  res_json <- exercise_result_to_json(res)
   expect_equal(
-    external_evaluator_result_from_json(res_json),
+    exercise_result_from_json(res_json),
     res,
     ignore_attr = TRUE
   )
@@ -444,10 +444,10 @@ test_that("external evaluator result roundtrip", {
   ex_no_output <- mock_exercise("x <- 1", exercise.warn_invisible = FALSE)
   res_no_output <- evaluate_exercise(ex_no_output, new.env())
 
-  res_no_output_json <- external_evaluator_result_to_json(res_no_output)
+  res_no_output_json <- exercise_result_to_json(res_no_output)
 
   expect_equal(
-    external_evaluator_result_from_json(res_no_output_json),
+    exercise_result_from_json(res_no_output_json),
     res_no_output,
     ignore_attr = TRUE
   )
@@ -461,8 +461,8 @@ test_that("external evaluator result roundtrip", {
   )
   res_fdbck <- do.call(exercise_result, res_fdbck)
 
-  res_fdbck_json <- external_evaluator_result_to_json(res_fdbck)
-  res_fdbck_rt <- external_evaluator_result_from_json(res_fdbck_json)
+  res_fdbck_json <- exercise_result_to_json(res_fdbck)
+  res_fdbck_rt <- exercise_result_from_json(res_fdbck_json)
 
   # Feedback HTML should resolve to the same raw HTML
   res_fdbck$feedback$html <- htmltools::HTML(format(res_fdbck$feedback$html))

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -477,6 +477,11 @@ test_that("exercise_result() throws an error for invalid feedback", {
   expect_error(exercise_result(feedback = list(correct = "wrong")))
 })
 
+test_that("exercise_result() turns length-0 html_output into NULL", {
+  expect_null(exercise_result(html_output = character())$html_output)
+  expect_null(exercise_result(html_output = list())$html_output)
+})
+
 test_that("exercise_result_as_html() creates html for learnr", {
   expect_null(exercise_result_as_html("nope"))
   expect_null(exercise_result_as_html(list()))

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -461,7 +461,8 @@ test_that("exercise_result() doesn't concatenate feedback and code output", {
   )
 
   expect_s3_class(result, "learnr_exercise_result")
-  expect_equal(result$html_output, "<pre><code>## output</code></pre>")
+  expect_s3_class(result$html_output, "html")
+  expect_equal(format(result$html_output), "<pre><code>## output</code></pre>")
   expect_equal(
     result$feedback$html,
     feedback_as_html(feedback)


### PR DESCRIPTION
Improve handling of external evaluator results, better error messages when conversion fails, improved tests around external evaluators.
