### PR TITLE
Create separate site for released & dev version

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -2,6 +2,9 @@ destination: reference
 
 url: https://pkgs.rstudio.com/learnr
 
+development: 
+  mode: auto
+  
 template:
   package: tidytemplate
   bootstrap: 5


### PR DESCRIPTION
This PR proposes a small but important change to the pkgdown site. IT enables `auto` [mode for pkgdown](https://pkgdown.r-lib.org/reference/build_site.html#development-mode) which creates two separate pages for the released and dev version of the package. 

This help your users avoid issues with a mismatch between the site and the installed CRAN package which can be very frustrating (as happened to me today). Example dev site for [reticulate](https://rstudio.github.io/reticulate/dev/).

As this is not a change to the package itself I did not update NEWS.
