### PR TITLE
Allow empty exercise code chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,8 @@
 
 -   Fixed exercise progress spinner being prematurely cleared (#384).
 
+-   Empty exercise chunks are now allowed. Please use caution: in very rare cases, knitr and learnr may not notice duplicate chunk labels when an exercise uses a duplicated label. Allowing empty exercise chunks improves the ergonomics when using [knitr's chunk option comments](https://yihui.org/en/2022/01/knitr-news/) (#712).
+
 ### Exercise Evaluation
 
 -   **Breaking Change:** If a `-code-check` chunk returns feedback for an exercise submission, the result of the exercise is no longer displayed for a correct answer (only the feedback is displayed). If both the result and feedback should be displayed, all checking should be performed in a `-check` chunk (i.e., don’t provide a `-code-check` chunk) (#403).

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -36,9 +36,11 @@ tutorial_knitr_options <- function() {
 
     chunk_opts <- attr(get_knitr_chunk(label), "chunk_opts")
     if (!identical(options$exercise, chunk_opts$exercise)) {
-      # this looks like an exercise chunk, but knitr has a different chunk that
-      # isn't an exercise here, so there must be a problem (i.e. this is an
-      # empty chunk that didn't trigger knitr's duplicate chunk error)
+      # this looks like an exercise chunk, but knitr knows about a different
+      # chunk that isn't an exercise here. so there must be a problem (i.e. this
+      # is an empty chunk that didn't trigger knitr's duplicate chunk error).
+      # Note that we can't rely on knit_code$get() or options$code since they
+      # both report the code for the non-exercise chunk.
       msg <- sprintf("Cannot create exercise '%s': duplicate chunk label", label)
       rlang::abort(msg)
     }
@@ -58,7 +60,11 @@ tutorial_knitr_options <- function() {
   ) {
     label <- current$label
 
-    # Recreate chunk options: unique to chunk or different from default
+    # Recreate chunk options: unique to chunk or different from default.
+    # Typically, we'd use `knit_code$get()` to find the chunk options defined
+    # directly on the chunk, but that returns `NULL` for empty chunks and
+    # doesn't include the chunk options. If we call this function in the options
+    # hooks, we have an opportunity to infer the chunk options.
     chunk_opts <- current[setdiff(names(current), names(all))]
     for (opt in names(all)) {
       if (!identical(all[[opt]], current[[opt]])) {

--- a/tests/testthat/test-knitr-hooks.R
+++ b/tests/testthat/test-knitr-hooks.R
@@ -87,3 +87,10 @@ test_that("Empty exercise code still creates an exercise", {
 
   expect_equal(ex_empty, ex_full)
 })
+
+test_that("Empty exercises with duplicate labels throw an error", {
+  local_edition(3)
+
+  rmd <- test_path("tutorials", "knitr-hooks_empty-exercise", "duplicate-label.Rmd")
+  expect_error(expect_message(get_tutorial_exercises(rmd), "duplicate"))
+})

--- a/tests/testthat/test-knitr-hooks.R
+++ b/tests/testthat/test-knitr-hooks.R
@@ -70,3 +70,20 @@ test_that("Detection of chained setup cycle works", {
     fixed = TRUE
   )
 })
+
+test_that("Empty exercise code still creates an exercise", {
+  local_edition(3)
+
+  # empty and full exercises are the same, except that "full" has empty lines
+  # in the exercise chunk. They should result in identical exercises.
+  rmd_empty <- test_path("tutorials", "knitr-hooks_empty-exercise", "empty-exercise.Rmd")
+  rmd_full <- test_path("tutorials", "knitr-hooks_empty-exercise", "full-exercise.Rmd")
+
+  ex_empty <- get_tutorial_exercises(rmd_empty)
+  ex_full <- get_tutorial_exercises(rmd_full)
+
+  # One small difference that doesn't matter at all...
+  ex_full$empty$options$code <- NULL
+
+  expect_equal(ex_empty, ex_full)
+})

--- a/tests/testthat/tutorials/knitr-hooks_empty-exercise/duplicate-label.Rmd
+++ b/tests/testthat/tutorials/knitr-hooks_empty-exercise/duplicate-label.Rmd
@@ -1,0 +1,41 @@
+---
+title: Empty Exercise Code with Duplicate
+output: learnr::tutorial
+runtime: shinyrmd
+---
+
+```{r setup, include = FALSE}
+library(learnr)
+tutorial_options(exercise.lines = 4L)
+
+knitr::opts_chunk$set(
+  echo = FALSE, 
+  custom_chunk_opt = "default",
+  fig.path = "figures",
+  cache.path = "cache"
+)
+```
+
+## Test
+
+### First empty
+
+This tutorial should fail to parse.
+
+```{r empty}
+
+
+```
+
+### Empty
+
+```{r empty, exercise = TRUE, custom_chunk_opt = "custom"}
+```
+
+```{r empty-hint}
+# hint code
+```
+
+```{r empty-solution}
+mtcars
+```

--- a/tests/testthat/tutorials/knitr-hooks_empty-exercise/empty-exercise.Rmd
+++ b/tests/testthat/tutorials/knitr-hooks_empty-exercise/empty-exercise.Rmd
@@ -1,0 +1,32 @@
+---
+title: Empty Exercise Code
+output: learnr::tutorial
+runtime: shinyrmd
+---
+
+```{r setup, include = FALSE}
+library(learnr)
+tutorial_options(exercise.lines = 4L)
+
+knitr::opts_chunk$set(
+  echo = FALSE, 
+  custom_chunk_opt = "default",
+  fig.path = "figures",
+  cache.path = "cache"
+)
+```
+
+## Test
+
+### Empty
+
+```{r empty, exercise = TRUE, custom_chunk_opt = "custom"}
+```
+
+```{r empty-hint}
+# hint code
+```
+
+```{r empty-solution}
+mtcars
+```

--- a/tests/testthat/tutorials/knitr-hooks_empty-exercise/full-exercise.Rmd
+++ b/tests/testthat/tutorials/knitr-hooks_empty-exercise/full-exercise.Rmd
@@ -1,0 +1,36 @@
+---
+title: Empty Exercise Code
+output: learnr::tutorial
+runtime: shinyrmd
+---
+
+```{r setup, include = FALSE}
+library(learnr)
+tutorial_options(exercise.lines = 4L)
+
+knitr::opts_chunk$set(
+  echo = FALSE, 
+  custom_chunk_opt = "default",
+  fig.path = "figures",
+  cache.path = "cache"
+)
+```
+
+## Test
+
+### Empty
+
+```{r empty, exercise = TRUE, custom_chunk_opt = "custom"}
+
+
+
+
+```
+
+```{r empty-hint}
+# hint code
+```
+
+```{r empty-solution}
+mtcars
+```


### PR DESCRIPTION
This PR relaxes the constraint introduced in #411 that exercises must contain at least one line (even empty).

Fixes #710

There is a little bit of wonkiness that can happen with empty chunks in knitr, and I've caught the most prevalent edge cases. Still, be careful that all chunk labels are unique, especially if you use empty exercise chunks.