### PR TITLE
Run shinytest2 tests only in PR branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,6 +64,12 @@ jobs:
           cache-version: 1
           extra-packages: any::rcmdcheck
 
+      # If events is a PR, set subdir to 'preview/pr<pr_number>'
+      - name: "[PR] Set optional tests in PR branch"
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "CI_IN_PR=true" >> $GITHUB_ENV
+
       - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -23,6 +23,15 @@ skip_if_pandoc <- function(ver = NULL) {
   }
 }
 
+skip_on_ci_if_not_pr <- function() {
+  # Don't skip locally
+  if (!nzchar(Sys.getenv("CI", ""))) return()
+  # If on CI, don't skip if envvar set by workflow is present
+  if (nzchar(Sys.getenv("CI_IN_PR", ""))) return()
+  # If on CI and not in a PR branch workflow... skip these tests
+  skip("Skipping on CI, tests run in PR checks only")
+}
+
 expect_marked_as <- function(object, correct, messages = NULL) {
   if (is.null(messages)) {
     expect_equal(object, mark_as(correct))

--- a/tests/testthat/test-shinytest2-aaa.R
+++ b/tests/testthat/test-shinytest2-aaa.R
@@ -1,5 +1,6 @@
 # https://github.com/rstudio/shinytest2/blob/c29b78e9/tests/testthat/test-aaa.R
 skip_on_cran() # Uses chromote
+skip_on_ci_if_not_pr()
 
 # Try to warm up chromote. IDK why it fails on older versions of R.
 test_that("Chromote loads", {

--- a/tests/testthat/test-shinytest2-hints.R
+++ b/tests/testthat/test-shinytest2-hints.R
@@ -1,6 +1,7 @@
 # test_that()
-
 skip_on_cran()
+skip_on_ci_if_not_pr()
+
 library(shinytest2)
 
 check_popover_exists <- function(id) {


### PR DESCRIPTION
The chromote-based shinytest2 tests can be flaky and exist primarily to specify behavior around a given feature. This PR disables shinytest2-based tests in the main branch but runs them in PR branches so they can be reviewed.
