### PR TITLE
Reset `indent` chunk option during render

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1200,6 +1200,7 @@ prepare_exercise <- function(exercise) {
     echo = FALSE,
     cache = FALSE,
     child = NULL,
+    indent = NULL,
     dev = "png",
     dpi = 92
   )


### PR DESCRIPTION
Fixes an issue caused by persisting the `indent` chunk option during exercise render. It's relevant for pre-render, but we can always render exercises without indent, since the HTML from `render_exercise()` is injected into the container created by the pre-render. In other words, the indent context doesn't matter for exercise rendering, just document pre-render.

Problematic exercise reprex:

````markdown
- Here's a bullet point that contains an exercise:

  ```{r indent-ul, exercise = TRUE}
  mtcars
  ```
  
  ```{r indent-ul-hint}
  # hint code
  ```
````