### PR TITLE
Account for question `type` possibly being a vector

### DIFF
--- a/R/question_methods.R
+++ b/R/question_methods.R
@@ -28,7 +28,9 @@
 #' @param value user input value
 #' @param ... future parameter expansion and custom arguments to be used in dispatched s3 methods.
 #'
-#' @seealso For more information and question type extension examples, please view the `question_type` tutorial: `learnr::run_tutorial("question_type", "learnr")`.
+#' @seealso For more information and question type extension examples, please
+#'   see the **Custom Question Types** section of the `quiz_question` tutorial:
+#'   `learnr::run_tutorial("quiz_question", "learnr")`.
 #'
 #' @export
 #' @rdname question_methods

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -744,7 +744,7 @@ question_ui_loading <- function(question) {
   })
 
   q_opts <- NULL
-  if (question$type %in% c("learnr_radio", "learnr_checkbox")) {
+  if (length(intersect(question$type, c("learnr_radio", "learnr_checkbox"))) > 0) {
     q_opts <- htmltools::tags$ul(
       lapply(seq_along(question$answers), function(...) {
         htmltools::tags$li(

--- a/inst/tutorials/quiz_question/quiz_question.Rmd
+++ b/inst/tutorials/quiz_question/quiz_question.Rmd
@@ -485,7 +485,7 @@ If a vector of types is supplied to a question's `type`, the S3 methods will be 
 ````markdown
 `r ''````{r custom_class, echo = FALSE}
 question_is_correct.always_correct <- function(question, value, ...) {
-  return(learnr::mark_as(TRUE, message = NULL))
+  return(learnr::mark_as(TRUE, messages = NULL))
 }
 
 ques <- question(
@@ -499,7 +499,7 @@ ques <- question(
 
 ```{r custom_class, echo = FALSE}
 question_is_correct.always_correct <- function(question, value, ...) {
-  return(learnr::mark_as(TRUE, message = NULL))
+  return(learnr::mark_as(TRUE, messages = NULL))
 }
 
 ques <- question(

--- a/man/question_methods.Rd
+++ b/man/question_methods.Rd
@@ -67,5 +67,7 @@ should correspond to the \code{type = TYPE} supplied to the question.
 }
 }
 \seealso{
-For more information and question type extension examples, please view the \code{question_type} tutorial: \code{learnr::run_tutorial("question_type", "learnr")}.
+For more information and question type extension examples, please
+see the \strong{Custom Question Types} section of the \code{quiz_question} tutorial:
+\code{learnr::run_tutorial("quiz_question", "learnr")}.
 }


### PR DESCRIPTION
Fixes #720 ... `question$type` may be a vector so we can't use `%in%` to compare to a set of target types.
