### PR TITLE
Fix: duplicate_py_env() to deep copy Python environment

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1401,8 +1401,8 @@ render_exercise_post_stage_hook.default <- function(exercise, ...) {
 
 #' @export
 render_exercise_post_stage_hook.python <- function(exercise, stage, envir, ...) {
-  # Add copy of python environment into the prep/restult environment
-  assign(".__py__", duplicate_py_env(py_global_env()), envir = envir)
+  # Add copy of python environment into the prep/result environment
+  assign(".__py__", duplicate_py_env(), envir = envir)
   invisible()
 }
 


### PR DESCRIPTION
Previously for Python exercises, we were doing a shallow copy using the `copy()` function of the `copy` module in Python. This causes issues for objects like `pandas.DataFrame` that have other objects nested inside, where `copy()` will copy by reference instead of by value.

This PR will instead use `copy.deepcopy()` on all Python objects besides modules to separate the prepping environment `envir_prep` from the user code `envir_result` environment.

TODOs:

- [ ] tests
