### PR TITLE
Give better hint for `question_checkbox()` in `try_again` message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,5 +72,5 @@ Config/Needs/coverage: covr
 Config/Needs/website: pkgdown, tidyverse/tidytemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org

--- a/R/question_checkbox.R
+++ b/R/question_checkbox.R
@@ -56,7 +56,7 @@ question_checkbox <- function(
   ...,
   correct = "Correct!",
   incorrect = "Incorrect",
-  try_again = incorrect,
+  try_again = "Incorrect. Be sure to select every correct answer.",
   allow_retry = FALSE,
   random_answer_order = FALSE
 ) {

--- a/R/question_checkbox.R
+++ b/R/question_checkbox.R
@@ -66,6 +66,7 @@ question_checkbox <- function(
     type = "learnr_checkbox",
     correct = correct,
     incorrect = incorrect,
+    try_again = try_again,
     allow_retry = allow_retry,
     random_answer_order = random_answer_order
   )

--- a/man/answer.Rd
+++ b/man/answer.Rd
@@ -51,9 +51,9 @@ evaluates the student's submission and returns a custom result.
 }
 \section{Functions}{
 \itemize{
-\item \code{answer}: Create an answer option
+\item \code{answer()}: Create an answer option
 
-\item \code{answer_fn}: Evaluate the student's submission to determine correctness
+\item \code{answer_fn()}: Evaluate the student's submission to determine correctness
 and to return feedback.
-}}
 
+}}

--- a/man/mock_exercise.Rd
+++ b/man/mock_exercise.Rd
@@ -78,11 +78,11 @@ having to create a learnr tutorial.
 }
 \section{Functions}{
 \itemize{
-\item \code{mock_exercise}: Create a learnr exercise object
+\item \code{mock_exercise()}: Create a learnr exercise object
 
-\item \code{mock_chunk}: Create a mock exercise-supporting chunk
+\item \code{mock_chunk()}: Create a mock exercise-supporting chunk
+
 }}
-
 \examples{
 mock_exercise(
   user_code = "1 + 1",

--- a/man/question_checkbox.Rd
+++ b/man/question_checkbox.Rd
@@ -9,7 +9,7 @@ question_checkbox(
   ...,
   correct = "Correct!",
   incorrect = "Incorrect",
-  try_again = incorrect,
+  try_again = "Incorrect. Be sure to select every correct answer.",
   allow_retry = FALSE,
   random_answer_order = FALSE
 )


### PR DESCRIPTION
Sets the default value of `try_again` in `question_checkbox()` to the message suggested in #731. This gives a better hint that there could be more than one answer and only when retries are allowed.

```r
question_checkbox(
  "What's the best package?",
  answer("tidyverse", correct = TRUE),
  answer("base", correct = TRUE),
  allow_retry = TRUE
)
#> Question: "What&#39;s the best package?"
#>   type: "learnr_checkbox"
#>   allow_retry: TRUE
#>   random_answer_order: FALSE
#>   answers:
#>     ✔: "tidyverse"
#>     ✔: "base"
#>   messages:
#>     correct: "Correct!"
#>     incorrect: "Incorrect"
#>     try_again: "Incorrect. Be sure to select every correct answer." 
```

https://user-images.githubusercontent.com/5420529/189210231-c1270b6e-101d-4137-b2e5-e4e35327e541.mov


