### PR TITLE
Use temporary directory for `get_tutorial_info()` example

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -91,12 +91,12 @@ jobs:
         shell: Rscript {0}
         run: |
           subdir <- "${{ env.subdir }}"
+          if (nzhcar(subdir)) {
+            Sys.setenv("PKGDOWN_DEV_MODE" = if (grepl("^v([0-9]+\\.?){3}$", subdir)) "released" else "unreleased")
+          }
           pkgdown::deploy_to_branch(
             subdir = if (nzchar(subdir)) subdir,
-            clean = nzchar(subdir),
-            override = if (!nzchar(subdir)) list() else list(
-              development = list(mode = if (grepl("^v([0-9]+\\.?){3}$", subdir)) "released" else "unreleased")
-            )
+            clean = nzchar(subdir)
           )
 
   pkgdown-clean:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -91,7 +91,7 @@ jobs:
         shell: Rscript {0}
         run: |
           subdir <- "${{ env.subdir }}"
-          if (nzhcar(subdir)) {
+          if (nzchar(subdir)) {
             Sys.setenv("PKGDOWN_DEV_MODE" = if (grepl("^v([0-9]+\\.?){3}$", subdir)) "released" else "unreleased")
           }
           pkgdown::deploy_to_branch(

--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -176,10 +176,20 @@ set_tutorial_state <- function(label, data, session = getDefaultReactiveDomain()
 #' correspond to the current tutorial.
 #'
 #' @examples
-#' tutorial_rmd <- system.file(
-#'   "tutorials", "hello", "hello.Rmd", package = "learnr"
-#' )
+#' tutorial_rmd <- local({
+#'   # Use a temp copy of "Hello learnr" tutorial for this example
+#'   src <- system.file(
+#'     "tutorials", "hello", "hello.Rmd", package = "learnr"
+#'   )
+#'   dest <- tempfile(fileext = ".Rmd")
+#'   file.copy(src, dest)
+#'   dest
+#' })
+#'
 #' get_tutorial_info(tutorial_rmd)
+#'
+#' # clean up the temporary Rmd used in this example
+#' unlink(tutorial_rmd)
 #'
 #' @inheritParams get_tutorial_state
 #' @param tutorial_path Path to a tutorial `.Rmd` source file

--- a/R/tutorial-state.R
+++ b/R/tutorial-state.R
@@ -176,20 +176,27 @@ set_tutorial_state <- function(label, data, session = getDefaultReactiveDomain()
 #' correspond to the current tutorial.
 #'
 #' @examples
-#' tutorial_rmd <- local({
-#'   # Use a temp copy of "Hello learnr" tutorial for this example
-#'   src <- system.file(
-#'     "tutorials", "hello", "hello.Rmd", package = "learnr"
-#'   )
-#'   dest <- tempfile(fileext = ".Rmd")
-#'   file.copy(src, dest)
-#'   dest
-#' })
+#' if (rmarkdown::pandoc_available("1.4")) {
+#'   tutorial_rmd <- local({
+#'     # Use a temp copy of "Hello learnr" tutorial for this example
+#'     src <- system.file(
+#'       "tutorials", "hello", "hello.Rmd", package = "learnr"
+#'     )
+#'     dest <- tempfile(fileext = ".Rmd")
+#'     file.copy(src, dest)
+#'     dest
+#'   })
 #'
-#' get_tutorial_info(tutorial_rmd)
+#'   # ---- This is the example! ------------ #
+#'   info <- get_tutorial_info(tutorial_rmd)
+#'   # -------------------------------------- #
 #'
-#' # clean up the temporary Rmd used in this example
-#' unlink(tutorial_rmd)
+#'   # clean up the temporary Rmd used in this example
+#'   unlink(tutorial_rmd)
+#'
+#'   # This is the result of the example
+#'   info
+#' }
 #'
 #' @inheritParams get_tutorial_state
 #' @param tutorial_path Path to a tutorial `.Rmd` source file

--- a/man/get_tutorial_info.Rd
+++ b/man/get_tutorial_info.Rd
@@ -108,10 +108,20 @@ the tutorial is completely initialized. If called in a non-reactive context,
 correspond to the current tutorial.
 }
 \examples{
-tutorial_rmd <- system.file(
-  "tutorials", "hello", "hello.Rmd", package = "learnr"
-)
+tutorial_rmd <- local({
+  # Use a temp copy of "Hello learnr" tutorial for this example
+  src <- system.file(
+    "tutorials", "hello", "hello.Rmd", package = "learnr"
+  )
+  dest <- tempfile(fileext = ".Rmd")
+  file.copy(src, dest)
+  dest
+})
+
 get_tutorial_info(tutorial_rmd)
+
+# clean up the temporary Rmd used in this example
+unlink(tutorial_rmd)
 
 }
 \seealso{


### PR DESCRIPTION
Fixes issue reported by CRAN by copying the example tutorial into the tempdir.

Fixes #737
