### PR TITLE
Fix unintentional dropping of html dependencies

### DIFF
--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1137,7 +1137,7 @@ exercise_result <- function(
     feedback$html <- feedback_as_html(feedback)
   }
 
-  if (is.character(html_output) && any(nzchar(html_output))) {
+  if (!inherits(html_output, "html") && is.character(html_output) && any(nzchar(html_output))) {
     html_output <- htmltools::HTML(html_output)
   } else if (length(html_output) == 0) {
     html_output <- NULL

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -501,6 +501,16 @@ test_that("exercise_result() turns length-0 html_output into NULL", {
   expect_null(exercise_result(html_output = list())$html_output)
 })
 
+test_that("exercise_result() doesn't drop html dependencies from `html_output`", {
+  html_output <- htmltools::attachDependencies(
+    htmltools::HTML("<p>A basic paragraph.</p>"),
+    clipboardjs_html_dependency()
+  )
+  res <- exercise_result(html_output = html_output)
+  expect_equal(as.character(res$html_output), as.character(html_output))
+  expect_equal(htmltools::htmlDependencies(res$html_output), list(clipboardjs_html_dependency()))
+})
+
 test_that("exercise_result_as_html() creates html for learnr", {
   expect_null(exercise_result_as_html("nope"))
   expect_null(exercise_result_as_html(list()))


### PR DESCRIPTION
- fix(exercise_result): Fix unintentional dropping of html dependencies
- test(exercise_result): Add test for broken behavior

Fixes #744. We were unintentionally dropping html dependencies because they are not preserved through `htmltools::HTML()`.

