### PR TITLE
Skip non-ASCII tests if system does not support UTF-8

### DIFF
--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -1213,6 +1213,8 @@ test_that("evaluate_exercise() returns message for unparsable non-ASCII code", {
 test_that("evaluate_exercise() does not return a message for parsable non-ASCII code", {
   skip_if_not_pandoc("1.14")
   skip_on_os("windows")
+  # Skip if OS does not support UTF-8
+  skip_if(!isTRUE(l10n_info()[["UTF-8"]]))
 
   # Greek variable name and interrobang in character string
   ex <- mock_exercise(

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -1212,14 +1212,20 @@ test_that("evaluate_exercise() returns message for unparsable non-ASCII code", {
 
 test_that("evaluate_exercise() does not return a message for parsable non-ASCII code", {
   skip_if_not_pandoc("1.14")
+
+  # Non-ASCII text in character string
+  ex <- mock_exercise(user_code = 'x <- "What\u203d"')
+  result <- evaluate_exercise(ex, new.env())
+  expect_null(result$feedback)
+
   skip_on_os("windows")
   # Skip if OS does not support UTF-8
   skip_if(!isTRUE(l10n_info()[["UTF-8"]]))
 
-  # Greek variable name and interrobang in character string
+  # Non-ASCII variable name
   ex <- mock_exercise(
     user_code =
-      '\u03bc\u03b5\u03c4\u03b1\u03b2\u03bb\u03b7\u03c4\u03ae <- "What\u203d"'
+      '\u03bc\u03b5\u03c4\u03b1\u03b2\u03bb\u03b7\u03c4\u03ae <- "What?"'
   )
   result <- evaluate_exercise(ex, new.env())
   expect_null(result$feedback)


### PR DESCRIPTION
Previously, tests that involved non-ASCII text were skipped on Windows, with the assumption that all Unix builds of R support UTF-8. Tests now explicitly check if the system supports UTF-8 to avoid a CRAN failure on non-Unicode Unix builds. This fix is [confirmed working on rhub's debian-clang-devel platform](https://builder.r-hub.io/status/learnr_0.11.1.9000.tar.gz-f4ea6f3709d247649483019af2aeb8c8), which forces a Latin-1 (non-UTF-8) locale.

Closes #748.