### PR TITLE
Fix issue with unevaluated `exercise` chunk option in learnr's knitr hooks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # learnr (development version)
 
+-   Fixed an issue that prevented authors from using symbols, such as `T` or a variable, as the value of the `exercise` chunk option, which caused tutorials with chunks with `exercise = T` to fail to render (thanks @cknotz #757, #758).
+
 # learnr 0.11.2
 
 -   Fixed an issue that prevented htmlwidgets from working in exercise code unless similar widgets were added to the tutorial prose (thanks @munoztd0 #744, #745).

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -34,8 +34,13 @@ tutorial_knitr_options <- function() {
       return(TRUE)
     }
 
-    chunk_opts <- attr(get_knitr_chunk(label), "chunk_opts")
-    if (!identical(options$exercise, chunk_opts$exercise)) {
+    chunk_opt_exercise <- attr(get_knitr_chunk(label), "chunk_opts")[["exercise"]]
+    if (is.symbol(chunk_opt_exercise)) {
+      # original chunk options might not be evaluated yet, see #757
+      chunk_opt_exercise <- eval(chunk_opt_exercise, knitr::knit_global())
+    }
+
+    if (!identical(options$exercise, chunk_opt_exercise)) {
       # this looks like an exercise chunk, but knitr knows about a different
       # chunk that isn't an exercise here. so there must be a problem (i.e. this
       # is an empty chunk that didn't trigger knitr's duplicate chunk error).

--- a/tests/testthat/test-knitr-hooks.R
+++ b/tests/testthat/test-knitr-hooks.R
@@ -96,3 +96,17 @@ test_that("Empty exercises with duplicate labels throw an error", {
   rmd <- test_path("tutorials", "knitr-hooks_empty-exercise", "duplicate-label.Rmd")
   expect_error(expect_message(get_tutorial_exercises(rmd), "duplicate"))
 })
+
+test_that("Exercise chunk option can be symbols", {
+  skip_if_not_pandoc("1.14")
+  local_edition(3)
+
+  rmd_src <- test_path("tutorials", "exercise-option-is-symbol.Rmd")
+  rmd <- withr::local_tempfile(fileext = ".Rmd")
+  html <- withr::local_tempfile(fileext = ".html")
+  file.copy(rmd_src, rmd, overwrite = TRUE)
+
+  expect_no_error(
+    rmarkdown::render(rmd, output_file = basename(html), quiet = TRUE)
+  )
+})

--- a/tests/testthat/tutorials/exercise-option-is-symbol.Rmd
+++ b/tests/testthat/tutorials/exercise-option-is-symbol.Rmd
@@ -1,0 +1,30 @@
+---
+title: "Test: Exercise Option is a Symbol"
+output: learnr::tutorial
+runtime: shiny_prerendered
+---
+
+```{r setup, include=FALSE}
+library(learnr)
+do_exercise <- TRUE
+knitr::opts_chunk$set(echo = FALSE)
+```
+
+
+## Topic
+
+### Exercise T
+
+*Here's a simple exercise with an empty code chunk provided for entering the answer.*
+
+Write the R code required to add two plus two:
+
+```{r symbol, exercise = T}
+"symbol"
+```
+
+### Exercise Variable
+
+```{r variable, exercise = do_exercise}
+"variable (also a symbol)"
+```


### PR DESCRIPTION
Fixes #757

If symbols – like `T` or a variable – are used in the `exercise` chunk option, this would cause an error in the checks that run to validate the exercise chunk by comparing with the source chunk because the source chunk options aren't yet evaluated.

This PR evaluates the source chunk option before comparing it with our exercise chunk.