### PR TITLE
Allow feedback on unparsable unicode characters to render without `i18next`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     digest,
     ellipsis (>= 0.2.0.1),
     evaluate,
+    glue,
     htmltools (>= 0.3.5),
     htmlwidgets,
     jsonlite,

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -1039,23 +1039,30 @@ exercise_check_unparsable_unicode <- function(exercise, error_message) {
   )
 }
 
-unparsable_unicode_message <- function(i18n_key, code, line, pattern, replacement_pattern = NULL) {
+unparsable_unicode_message <- function(
+  i18n_key, code, line, pattern, replacement_pattern = NULL
+) {
   code <- unlist(strsplit(code, "\n"))[[line]]
 
   character <- str_extract(code, pattern)
-  highlighted_code <- exercise_highlight_unparsable_unicode(code, pattern, line)
 
-  suggestion <- NULL
-  if (!is.null(replacement_pattern)) {
-    suggestion <- html_code_block(str_replace_all(code, replacement_pattern))
+  suggestion <- if (!is.null(replacement_pattern)) {
+    html_code_block(str_replace_all(code, replacement_pattern))
+  } else {
+    NULL
   }
+
+  code <- exercise_highlight_unparsable_unicode(code, pattern, line)
+
+  text <- i18n_translations()$en$translation$text[[i18n_key]]
+  text <- glue::glue(text, .open = "{{", .close = "}}")
 
   i18n_div(
     paste0("text.", i18n_key),
-    HTML(i18n_translations()$en$translation$text[[i18n_key]]),
+    HTML(text),
     opts = list(
       character = character,
-      code = highlighted_code,
+      code = code,
       suggestion = suggestion,
       interpolation = list(escapeValue = FALSE)
     )

--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -1171,52 +1171,42 @@ test_that("Errors with global setup code result in an internal error", {
 test_that("evaluate_exercise() returns message for unparsable non-ASCII code", {
   skip_if_not_pandoc("1.14")
 
+  expect_unparsable_message <- function(user_code, problem, key) {
+    ex <- mock_exercise(user_code = user_code)
+    feedback <- evaluate_exercise(ex, new.env())$feedback
+    expect_equal(feedback, exercise_check_code_is_parsable(ex)$feedback)
+    expect_match(feedback$message, regexp = key, fixed = TRUE)
+    for (character in problem) {
+      expect_match(feedback$message, regexp = character, fixed = TRUE)
+    }
+  }
+
   # Curly double quotes
-  ex <- mock_exercise(
-    user_code = "str_detect(\u201ctest\u201d, \u201ct.+t\u201d)"
-  )
-  result <- evaluate_exercise(ex, new.env())
-  expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
-  expect_match(result$feedback$message, "text.unparsablequotes")
-  expect_match(
-    result$feedback$message,
-    i18n_translations()$en$translation$text$unparsablequotes,
-    fixed = TRUE
+  expect_unparsable_message(
+    "str_detect(\u201ctest\u201d, \u201ct.+t\u201d)",
+    problem = c("\u201c", "\u201d"),
+    key = "text.unparsablequotes"
   )
 
   # Curly single quotes
-  ex <- mock_exercise(
-    user_code = "str_detect(\u2018test\u2019, \u2018t.+t\u2019)"
-  )
-  result <- evaluate_exercise(ex, new.env())
-  expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
-  expect_match(result$feedback$message, "text.unparsablequotes")
-  expect_match(
-    result$feedback$message,
-    i18n_translations()$en$translation$text$unparsablequotes,
-    fixed = TRUE
+  expect_unparsable_message(
+    "str_detect(\u2018test\u2019, \u2018t.+t\u2019)",
+    problem = c("\u2018", "\u2019"),
+    key = "text.unparsablequotes"
   )
 
   # En dash
-  ex     <- mock_exercise(user_code = "63 \u2013 21")
-  result <- evaluate_exercise(ex, new.env())
-  expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
-  expect_match(result$feedback$message, "text.unparsableunicodesuggestion")
-  expect_match(
-    result$feedback$message,
-    i18n_translations()$en$translation$text$unparsableunicodesuggestion,
-    fixed = TRUE
+  expect_unparsable_message(
+    "63 \u2013 21",
+    problem = "\u2013",
+    key = "text.unparsableunicodesuggestion"
   )
 
   # Plus-minus sign
-  ex     <- mock_exercise(user_code = "63 \u00b1 21")
-  result <- evaluate_exercise(ex, new.env())
-  expect_equal(result$feedback, exercise_check_code_is_parsable(ex)$feedback)
-  expect_match(result$feedback$message, "text.unparsableunicode")
-  expect_match(
-    result$feedback$message,
-    i18n_translations()$en$translation$text$unparsableunicode,
-    fixed = TRUE
+  expect_unparsable_message(
+    "63 \u00b1 21",
+    problem = "\u00b1",
+    key = "text.unparsableunicode"
   )
 })
 


### PR DESCRIPTION
Pre-interpolate message generated by `unparsable_unicode_message()` so feedback is comprehensible when `i18next` is unavailable.

Previously, if `i18next` was unavailable, the feedback would contain uninterpolated strings, like this:

> It looks like your R code contains an unexpected special character (`{{character}}`) that makes your code invalid.
> {{code}}
> Sometimes your code may contain a special character that looks like a regular character, especially if you copy and paste the code from another app. You can try replacing the code on that line with the following. There may be other places that need to be fixed, too.
> {{suggestion}} 

This PR adds a dependency on `glue`, which provides an elegant way to pre-interpolate the string, but isn't strictly necessary. If we'd like to avoid adding a dependency, I can refactor to just use regex.

PR task list:
- [ ] Update NEWS
- [x] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
