### PR TITLE
Use markdown::mark() instead of mark_html(options = '-standalone')

### DIFF
--- a/R/quiz.R
+++ b/R/quiz.R
@@ -252,7 +252,7 @@ quiz_text <- function(text) {
       text <- format(text)
     }
     # convert markdown
-    md <- markdown::mark_html(text = text, options = "-standalone")
+    md <- markdown::mark(text = text)
     if (length(str_match_all(md, "</p>", fixed = TRUE)) == 1) {
       # remove leading and trailing paragraph
       md <- sub("^<p>", "", md)


### PR DESCRIPTION
`mark()` defaults to generating a fragment, so this way is slightly cleaner.

This is quite a trivial change, so probably not worth a mention in NEWS.

PR task list:
- [ ] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
