### PR TITLE
Fix tests for exercise errors

### DIFF
--- a/tests/testthat/test-exercise.R
+++ b/tests/testthat/test-exercise.R
@@ -125,7 +125,7 @@ test_that("render_exercise() returns envir_result up to error", {
     )
   )
 
-  expect_s3_class(exercise_result$parent, "simpleError")
+  expect_s3_class(exercise_result$parent, "error")
   expect_equal(conditionMessage(exercise_result$parent), "boom")
 
   expect_false(
@@ -181,7 +181,7 @@ test_that("evaluate_exercise() errors from setup chunks aren't checked by error 
   )
   expect_match(exercise_result$feedback$message, "internal error occurred")
   # internal error condition is passed around in $feedback$error
-  expect_s3_class(exercise_result$feedback$error, "simpleError")
+  expect_s3_class(exercise_result$feedback$error, "error")
   expect_match(conditionMessage(exercise_result$feedback$error), "setup")
 })
 
@@ -198,7 +198,7 @@ test_that("evaluate_exercise() errors from user code are checked by error_checke
   # check that error check function was called
   expect_equal(exercise_result$feedback$checker_result, "error_check")
   expect_equal(exercise_result$error_message, "user")
-  expect_s3_class(exercise_result$feedback$checker_args$last_value, "simpleError")
+  expect_s3_class(exercise_result$feedback$checker_args$last_value, "error")
   expect_equal(
     conditionMessage(exercise_result$feedback$checker_args$last_value),
     exercise_result$error_message
@@ -219,7 +219,7 @@ test_that("evaluate_exercise() errors from user code are checked by default erro
   # check that default error check function was called
   expect_equal(exercise_result$feedback$checker_result, "default_error_check")
   expect_equal(exercise_result$error_message, "user")
-  expect_s3_class(exercise_result$feedback$checker_args$last_value, "simpleError")
+  expect_s3_class(exercise_result$feedback$checker_args$last_value, "error")
   expect_equal(
     conditionMessage(exercise_result$feedback$checker_args$last_value),
     exercise_result$error_message
@@ -236,7 +236,7 @@ test_that("evaluate_exercise() returns an internal error for global setup chunk 
   )
   expect_equal(conditionMessage(res$feedback$error), "global setup failure")
   expect_match(res$feedback$message, "setting up the tutorial")
-  expect_s3_class(res$feedback$error, "simpleError")
+  expect_s3_class(res$feedback$error, "error")
 })
 
 test_that("evaluate_exercise() returns an internal error when `render_exercise()` fails", {
@@ -251,7 +251,7 @@ test_that("evaluate_exercise() returns an internal error when `render_exercise()
   )
 
   expect_match(res$feedback$message, "evaluating your exercise")
-  expect_s3_class(res$feedback$error, "simpleError")
+  expect_s3_class(res$feedback$error, "error")
   expect_equal(conditionMessage(res$feedback$error), "render error")
 })
 
@@ -458,7 +458,7 @@ test_that("evaluate_exercise() handles default vs. explicit error check code", {
 
   res <- evaluate_exercise(ex, new.env())
   expect_equal(res$feedback$checker_result, "default_error_check_code")
-  expect_s3_class(res$feedback$checker_args$last_value, "simpleError")
+  expect_s3_class(res$feedback$checker_args$last_value, "error")
   expect_match(conditionMessage(res$feedback$checker_args$last_value), "boom")
 })
 
@@ -1162,7 +1162,7 @@ test_that("Errors with global setup code result in an internal error", {
 
   expect_null(res$error_message)
   expect_match(res$feedback$message, "internal error occurred while setting up the tutorial")
-  expect_s3_class(res$feedback$error, "simpleError")
+  expect_s3_class(res$feedback$error, "error")
   expect_match(conditionMessage(res$feedback$error), "boom")
 })
 

--- a/tests/testthat/test-question_numeric.R
+++ b/tests/testthat/test-question_numeric.R
@@ -12,27 +12,27 @@ test_that("question_numeric() correctly grades a question", {
   # correct
   ans <- question_is_correct(q, 1.234)
   expect_true(ans$correct)
-  expect_match(ans$message, "yes", fixed = TRUE)
+  expect_match(ans$messages, "yes", fixed = TRUE)
 
   # below lower bound
   ans <- question_is_correct(q, 0)
   expect_false(ans$correct)
-  expect_match(ans$message, "at least 1", fixed = TRUE)
+  expect_match(ans$messages, "at least 1", fixed = TRUE)
 
   # above upper bound
   ans <- question_is_correct(q, 3.5)
   expect_false(ans$correct)
-  expect_match(ans$message, "at most 2", fixed = TRUE)
+  expect_match(ans$messages, "at most 2", fixed = TRUE)
 
   # above upper bound and specifically wrong
   ans <- question_is_correct(q, 3)
   expect_false(ans$correct)
-  expect_match(ans$message, "three", fixed = TRUE)
+  expect_match(ans$messages, "three", fixed = TRUE)
 
   # within bound and specifically wrong
   ans <- question_is_correct(q, 1.2)
   expect_false(ans$correct)
-  expect_match(ans$message, "one two", fixed = TRUE)
+  expect_match(ans$messages, "one two", fixed = TRUE)
 })
 
 test_that("question_numeric() checks inputs", {


### PR DESCRIPTION
Fixes #780 by testing exercise errors for `"error"` class rather than `"simpleError"`.