### PR TITLE
Give better hint for checkbox questions created with `question()` in `try_again` message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # learnr (development version)
 
 -   Moved curl from Imports to Suggests. curl is only required when using an external evaluator (#776).
--   the default "try again" message for checkbox questions now prompts the student to "select every correct answer" regardless of whether the question was created by `qustion()` or `question_checkbox()` (#783).
+-   The default `try_again` message for checkbox questions now prompts the student to "select every correct answer" regardless of whether the question was created by `qustion()` or `question_checkbox()` (#783).
 
 # learnr 0.11.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # learnr (development version)
 
 -   Moved curl from Imports to Suggests. curl is only required when using an external evaluator (#776).
+-   the default "try again" message for checkbox questions now prompts the student to "select every correct answer" regardless of whether the question was created by `qustion()` or `question_checkbox()` (#783).
 
 # learnr 0.11.3
 

--- a/R/question_checkbox.R
+++ b/R/question_checkbox.R
@@ -70,7 +70,6 @@ question_checkbox <- function(
     correct = correct,
     incorrect = incorrect,
     try_again = try_again,
-    try_again_checkbox = try_again,
     allow_retry = allow_retry,
     random_answer_order = random_answer_order
   )

--- a/R/question_checkbox.R
+++ b/R/question_checkbox.R
@@ -42,6 +42,9 @@
 #' )
 #'
 #' @inheritParams question
+#' @param try_again Text to print for an incorrect answer
+#'   (defaults to "Incorrect. Be sure to select every correct answer.")
+#'   when `allow_retry` is `TRUE`.
 #' @param ... Answers created with [answer()] or [answer_fn()], or extra
 #'   parameters passed onto [question()]. Function answers do not
 #'   appear in the checklist, but are checked first in the order they are
@@ -67,6 +70,7 @@ question_checkbox <- function(
     correct = correct,
     incorrect = incorrect,
     try_again = try_again,
+    try_again_checkbox = try_again,
     allow_retry = allow_retry,
     random_answer_order = random_answer_order
   )

--- a/R/question_numeric.R
+++ b/R/question_numeric.R
@@ -27,6 +27,8 @@
 #'   step = 1
 #' )
 #'
+#' @param try_again Text to print for an incorrect answer (defaults to
+#'   "Incorrect") when `allow_retry` is `TRUE`.
 #' @param tolerance Submitted values within an absolute difference less than or
 #'   equal to `tolerance` will be considered equal to the answer value. Note
 #'   that this tolerance is for all [answer()] values. For more specific answer

--- a/R/question_radio.R
+++ b/R/question_radio.R
@@ -16,6 +16,8 @@
 #' )
 #'
 #' @inheritParams question
+#' @param try_again Text to print for an incorrect answer (defaults to
+#'   "Incorrect") when `allow_retry` is `TRUE`.
 #' @param ... Answers created with [answer()] or extra parameters passed onto
 #'   [question()]. Function answers are ignored for radio questions because the
 #'   user is required to select a single answer.

--- a/R/question_text.R
+++ b/R/question_text.R
@@ -37,6 +37,8 @@
 #'   }, label = "fizz or buzz")
 #' )
 #'
+#' @param try_again Text to print for an incorrect answer (defaults to
+#'   "Incorrect") when `allow_retry` is `TRUE`.
 #' @param rows,cols Defines the size of the text input area in terms of the
 #'   number of rows or character columns visible to the user. If either `rows`
 #'   or `cols` are provided, the quiz input will use [shiny::textAreaInput()]

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -65,11 +65,10 @@
 #'   correct.
 #' @param incorrect Text to print for an incorrect answer (defaults to
 #'   "Incorrect") when `allow_retry` is `FALSE`.
-#' @param try_again Text to print for an incorrect answer (defaults to
-#'   "Incorrect") when `allow_retry` is `TRUE` and `type` is not `"checkbox"`.
-#' @param try_again_checkbox Text to print for an incorrect answer
-#'   (defaults to "Incorrect. Be sure to select every correct answer.")
-#'   when `allow_retry` is `TRUE` and `type` is `"checkbox"`.
+#' @param try_again Text to print for an incorrect answer when `allow_retry`
+#'   is `TRUE`.
+#'   Defaults to "Incorrect. Be sure to select every correct answer." for
+#'   checkbox questions and "Incorrect" for non-checkbox questions.
 #' @param message Additional message to display along with correct/incorrect
 #'   feedback. This message is always displayed after a question submission.
 #' @param post_message Additional message to display along with
@@ -138,8 +137,7 @@ question <- function(
     type = c("auto", "single", "multiple", "learnr_radio", "learnr_checkbox", "learnr_text", "learnr_numeric"),
     correct = "Correct!",
     incorrect = "Incorrect",
-    try_again = incorrect,
-    try_again_checkbox = "Incorrect. Be sure to select every correct answer.",
+    try_again = NULL,
     message = NULL,
     post_message = NULL,
     loading = NULL,
@@ -189,10 +187,12 @@ question <- function(
       type
     )
   }
-  try_again <- if (identical(type, "learnr_checkbox")) {
-    try_again_checkbox
-  } else {
-    try_again
+  if (is.null(try_again)) {
+    try_again <- if (identical(type, "learnr_checkbox")) {
+      "Incorrect. Be sure to select every correct answer."
+    } else {
+      incorrect
+    }
   }
 
   # ensure we have at least one correct answer, if required

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -59,14 +59,17 @@
 #'   even though multiple correct answers are specified that inputs which
 #'   include only one correct answer are still correct. Pass `"checkbox"` to
 #'   force the use of checkboxes (as opposed to radio buttons) even though only
-#'   once correct answer was provided.
+#'   one correct answer was provided.
 #' @param correct For `question`, text to print for a correct answer (defaults
 #'   to "Correct!"). For `answer`, a boolean indicating whether this answer is
 #'   correct.
 #' @param incorrect Text to print for an incorrect answer (defaults to
 #'   "Incorrect") when `allow_retry` is `FALSE`.
 #' @param try_again Text to print for an incorrect answer (defaults to
-#'   "Incorrect") when `allow_retry` is `TRUE`.
+#'   "Incorrect") when `allow_retry` is `TRUE` and `type` is not `"checkbox"`.
+#' @param try_again_checkbox Text to print for an incorrect answer
+#'   (defaults to "Incorrect. Be sure to select every correct answer.")
+#'   when `allow_retry` is `TRUE` and `type` is `"checkbox"`.
 #' @param message Additional message to display along with correct/incorrect
 #'   feedback. This message is always displayed after a question submission.
 #' @param post_message Additional message to display along with
@@ -136,6 +139,7 @@ question <- function(
     correct = "Correct!",
     incorrect = "Incorrect",
     try_again = incorrect,
+    try_again_checkbox = "Incorrect. Be sure to select every correct answer.",
     message = NULL,
     post_message = NULL,
     loading = NULL,
@@ -184,6 +188,11 @@ question <- function(
       # allows for s3 methods
       type
     )
+  }
+  try_again <- if (identical(type, "learnr_checkbox")) {
+    try_again_checkbox
+  } else {
+    try_again
   }
 
   # ensure we have at least one correct answer, if required

--- a/man/question_checkbox.Rd
+++ b/man/question_checkbox.Rd
@@ -29,8 +29,9 @@ correct.}
 \item{incorrect}{Text to print for an incorrect answer (defaults to
 "Incorrect") when \code{allow_retry} is \code{FALSE}.}
 
-\item{try_again}{Text to print for an incorrect answer (defaults to
-"Incorrect") when \code{allow_retry} is \code{TRUE}.}
+\item{try_again}{Text to print for an incorrect answer
+(defaults to "Incorrect. Be sure to select every correct answer.")
+when \code{allow_retry} is \code{TRUE}.}
 
 \item{allow_retry}{Allow retry for incorrect answers. Defaults to \code{FALSE}.}
 

--- a/man/quiz.Rd
+++ b/man/quiz.Rd
@@ -14,8 +14,7 @@ question(
     "learnr_text", "learnr_numeric"),
   correct = "Correct!",
   incorrect = "Incorrect",
-  try_again = incorrect,
-  try_again_checkbox = "Incorrect. Be sure to select every correct answer.",
+  try_again = NULL,
   message = NULL,
   post_message = NULL,
   loading = NULL,
@@ -47,12 +46,10 @@ correct.}
 \item{incorrect}{Text to print for an incorrect answer (defaults to
 "Incorrect") when \code{allow_retry} is \code{FALSE}.}
 
-\item{try_again}{Text to print for an incorrect answer (defaults to
-"Incorrect") when \code{allow_retry} is \code{TRUE} and \code{type} is not \code{"checkbox"}.}
-
-\item{try_again_checkbox}{Text to print for an incorrect answer
-(defaults to "Incorrect. Be sure to select every correct answer.")
-when \code{allow_retry} is \code{TRUE} and \code{type} is \code{"checkbox"}.}
+\item{try_again}{Text to print for an incorrect answer when \code{allow_retry}
+is \code{TRUE}.
+Defaults to "Incorrect. Be sure to select every correct answer." for
+checkbox questions and "Incorrect" for non-checkbox questions.}
 
 \item{message}{Additional message to display along with correct/incorrect
 feedback. This message is always displayed after a question submission.}

--- a/man/quiz.Rd
+++ b/man/quiz.Rd
@@ -15,6 +15,7 @@ question(
   correct = "Correct!",
   incorrect = "Incorrect",
   try_again = incorrect,
+  try_again_checkbox = "Incorrect. Be sure to select every correct answer.",
   message = NULL,
   post_message = NULL,
   loading = NULL,
@@ -37,7 +38,7 @@ determined based on the provided answers. Pass \code{"radio"} to indicate that
 even though multiple correct answers are specified that inputs which
 include only one correct answer are still correct. Pass \code{"checkbox"} to
 force the use of checkboxes (as opposed to radio buttons) even though only
-once correct answer was provided.}
+one correct answer was provided.}
 
 \item{correct}{For \code{question}, text to print for a correct answer (defaults
 to "Correct!"). For \code{answer}, a boolean indicating whether this answer is
@@ -47,7 +48,11 @@ correct.}
 "Incorrect") when \code{allow_retry} is \code{FALSE}.}
 
 \item{try_again}{Text to print for an incorrect answer (defaults to
-"Incorrect") when \code{allow_retry} is \code{TRUE}.}
+"Incorrect") when \code{allow_retry} is \code{TRUE} and \code{type} is not \code{"checkbox"}.}
+
+\item{try_again_checkbox}{Text to print for an incorrect answer
+(defaults to "Incorrect. Be sure to select every correct answer.")
+when \code{allow_retry} is \code{TRUE} and \code{type} is \code{"checkbox"}.}
 
 \item{message}{Additional message to display along with correct/incorrect
 feedback. This message is always displayed after a question submission.}

--- a/tests/testthat/test-question_checkbox.R
+++ b/tests/testthat/test-question_checkbox.R
@@ -35,6 +35,37 @@ test_that("question_checkbox() does not include correct messages for incorrect a
   expect_marked_as(question_is_correct(q, "F"), correct = FALSE)
 })
 
+test_that("question_checkbox() message depends on whether allow_retry = TRUE", {
+
+  incorrect_message <- "incorrect"
+  try_again_message <- "try_again"
+
+  q <- question_checkbox(
+    "test",
+    answer("A", correct = TRUE),
+    answer("B", correct = TRUE),
+    answer("C", correct = FALSE),
+    incorrect = incorrect_message,
+    try_again = try_again_message
+  )
+
+  out_no_retry <- question_messages(
+    question = q,
+    messages = NULL,
+    is_correct = FALSE,
+    is_done = TRUE
+  )
+  expect_equal(as.character(out_no_retry[[1]]$children[[1]]), incorrect_message)
+
+  out_retry <- question_messages(
+    question = q,
+    messages = NULL,
+    is_correct = FALSE,
+    is_done = FALSE
+  )
+  expect_equal(as.character(out_retry[[1]]$children[[1]]), try_again_message)
+})
+
 test_that("question_checkbox() evaluates function answers first", {
   q <- question_checkbox(
     "test",

--- a/tests/testthat/test-quiz.R
+++ b/tests/testthat/test-quiz.R
@@ -129,3 +129,52 @@ test_that("loading placeholder is correctly generated for HTML question texts", 
     )
   )
 })
+
+test_that("question() message depends on whether type is checkbox", {
+
+  incorrect_message <- "incorrect"
+  try_again_radio_message <- "try_again_radio"
+  try_again_checkbox_message <- "try_again_checkbox"
+
+  q_radio <- question(
+    "test",
+    answer("A", correct = TRUE),
+    answer("B", correct = FALSE),
+    answer("C", correct = FALSE),
+    incorrect = incorrect_message,
+    try_again = try_again_radio_message,
+    try_again_checkbox = try_again_checkbox_message
+  )
+
+  out_radio <- question_messages(
+    question = q_radio,
+    messages = NULL,
+    is_correct = FALSE,
+    is_done = FALSE
+  )
+  expect_equal(
+    as.character(out_radio[[1]]$children[[1]]),
+    try_again_radio_message
+  )
+
+  q_checkbox <- question(
+    "test",
+    answer("A", correct = TRUE),
+    answer("B", correct = TRUE),
+    answer("C", correct = FALSE),
+    incorrect = incorrect_message,
+    try_again = try_again_radio_message,
+    try_again_checkbox = try_again_checkbox_message
+  )
+
+  out_checkbox <- question_messages(
+    question = q_checkbox,
+    messages = NULL,
+    is_correct = FALSE,
+    is_done = FALSE
+  )
+  expect_equal(
+    as.character(out_checkbox[[1]]$children[[1]]),
+    try_again_checkbox_message
+  )
+})

--- a/tests/testthat/test-quiz.R
+++ b/tests/testthat/test-quiz.R
@@ -132,18 +132,11 @@ test_that("loading placeholder is correctly generated for HTML question texts", 
 
 test_that("question() message depends on whether type is checkbox", {
 
-  incorrect_message <- "incorrect"
-  try_again_radio_message <- "try_again_radio"
-  try_again_checkbox_message <- "try_again_checkbox"
-
   q_radio <- question(
     "test",
     answer("A", correct = TRUE),
     answer("B", correct = FALSE),
-    answer("C", correct = FALSE),
-    incorrect = incorrect_message,
-    try_again = try_again_radio_message,
-    try_again_checkbox = try_again_checkbox_message
+    answer("C", correct = FALSE)
   )
 
   out_radio <- question_messages(
@@ -154,17 +147,14 @@ test_that("question() message depends on whether type is checkbox", {
   )
   expect_equal(
     as.character(out_radio[[1]]$children[[1]]),
-    try_again_radio_message
+    "Incorrect"
   )
 
   q_checkbox <- question(
     "test",
     answer("A", correct = TRUE),
     answer("B", correct = TRUE),
-    answer("C", correct = FALSE),
-    incorrect = incorrect_message,
-    try_again = try_again_radio_message,
-    try_again_checkbox = try_again_checkbox_message
+    answer("C", correct = FALSE)
   )
 
   out_checkbox <- question_messages(
@@ -175,6 +165,6 @@ test_that("question() message depends on whether type is checkbox", {
   )
   expect_equal(
     as.character(out_checkbox[[1]]$children[[1]]),
-    try_again_checkbox_message
+    "Incorrect. Be sure to select every correct answer."
   )
 })


### PR DESCRIPTION
This PR extends #732 to apply to checkbox questions created by `question()` in addition to checkbox questions created by `question_checkbox()`. It does this by changing the default value of `try_again` in `question()` to `NULL`. If `try_again` is `NULL`, `question()` determines the default message based on the question `type`.

Closes #782.