### PR TITLE
fix(knitr-hooks): Ensure `label` is unnamed string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 -   You can now customize the "continue" button text in sub-topics by adding 'data-continue-text' with your custom label as a property of the section heading — e.g. `### Subtopic Title {data-continue-text="Show Solution"}` (@dave-mills #777).
 
+-   learnr tutorials now work when Quarto comment-style chunk options are used to set the chunk `label` (thanks @jimjam-slam, #795).
+
 # learnr 0.11.4
 
 -   Moved curl from Imports to Suggests. curl is only required when using an external evaluator (#776).

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -245,6 +245,8 @@ tutorial_knitr_options <- function() {
 
   # hook to turn off evaluation/highlighting for exercise related chunks
   tutorial_opts_hook <-  function(options) {
+    # ensure label is an unnamed string (yihui/knitr#2280)
+    options$label <- unname(options$label)
 
     # check for chunk type
     exercise_chunk <- is_exercise_chunk(options)


### PR DESCRIPTION
Fixes #795

Uses the tutorial option hook to ensure that the chunk label is always an unnamed string. This is applied globally to every chunk in a learnr tutorial and thereby avoids yihui/knitr#2280.