### PR TITLE
tests: Skip i18n message translation tests when `LC_ALL="C"` or `"C.UTF-8"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 -   learnr tutorials now work when Quarto comment-style chunk options are used to set the chunk `label` (thanks @jimjam-slam, #795).
 
+-   When the `LC_ALL` environment variable is `"C"` or `"C.UTF-8"`, R may ignore the `LANGUAGE` environment variable, which means that learnr may not be able to control the language of R's messages. learnr's tests no longer test R message translations in these cases. If you are deploying a tutorial written in a language other than English, you should ensure that the `LC_ALL` environment variable is not set to `"C"` or `"C.UTF-8"` and you may need to set the `LANGUAGE` variable via an `.Renviron` file rather than relying on learnr (#801).
+
 # learnr 0.11.4
 
 -   Moved curl from Imports to Suggests. curl is only required when using an external evaluator (#776).

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -184,49 +184,78 @@ i18n_set_language_option <- function(language = NULL) {
 
 i18n_setenv_language <- function(lang) {
   lang <- i18n_determine_base_r_language(lang)
+  could_set_language <- i18n_try_setenv_language(lang)
 
-  old_lang <- Sys.getenv("LANGUAGE", unset = "en")
-  old_text <- gettext("subscript out of bounds", domain = "R")
-
-  Sys.setenv("LANGUAGE" = lang)
-
-  new_lang <- Sys.getenv("LANGUAGE", unset = "en")
-  new_text <- gettext("subscript out of bounds", domain = "R")
-
-  if (!identical(old_lang, new_lang) && identical(old_text, new_text)) {
-    # On Linux, message translations are cached
-    # Messages from the old language may be shown in the new language
-    # If this happens, invalidate the cache so new messages have to generate
-    base_dir <- bindtextdomain("R-base")
-    bindtextdomain("R-base", tempfile())
-    bindtextdomain("R-base", base_dir)
+  if (identical(could_set_language, FALSE)) {
+    rlang::warn(c(
+      "This version of R does not support changing the current language. Messages from R will not be translated.",
+      "i" = sprintf("The requested language was %s", lang),
+      "i" = sprintf("The current language is %s", Sys.getenv("LANGUAGE", unset = "en"))
+    ))
   }
 }
 
+i18n_try_setenv_language <- function(lang) {
+  lang <- i18n_determine_base_r_language(lang)
+
+  old_lang <- Sys.getenv("LANGUAGE", unset = "en")
+
+  if (identical(lang, i18n_determine_base_r_language(old_lang))) {
+    return(NA)
+  }
+
+  i18n_invalidate_language_cache()
+  old_text <- gettext("subscript out of bounds", domain = "R")
+  Sys.setenv("LANGUAGE" = lang)
+
+  new_lang <- Sys.getenv("LANGUAGE", unset = "en")
+  i18n_invalidate_language_cache()
+  new_text <- gettext("subscript out of bounds", domain = "R")
+
+  !identical(old_text, new_text)
+}
+
+i18n_invalidate_language_cache <- function() {
+  # On Linux, message translations are cached
+  # Messages from the old language may be shown in the new language
+  # If this happens, invalidate the cache so new messages have to generate
+  base_dir <- bindtextdomain("R-base")
+  bindtextdomain("R-base", tempfile())
+  bindtextdomain("R-base", base_dir)
+}
+
 i18n_determine_base_r_language <- function(lang) {
+  if (inherits(lang, "learnr_i18n_lang")) {
+    return(lang)
+  }
+
   lang <- gsub("-", "_", lang)
 
   # Find available translations of base R
   base_langs <- dir(bindtextdomain("R"))
   base_langs <- base_langs[grepl("^[a-z]{2,3}(_[A-Z]{2})?$", base_langs)]
 
+  as_learnr_lang <- function(lang) {
+    structure(lang, class = "learnr_i18n_lang")
+  }
+
   # If `lang` is a base R translation, return `lang`
   if (!length(base_langs) || lang %in% base_langs) {
-    return(lang)
+    return(as_learnr_lang(lang))
   }
 
   lang_code <- substr(lang, 1, 2)
 
   # If `lang` is a variant of English, base R does not need to be translated
   if (lang_code == "en") {
-    return(lang)
+    return(as_learnr_lang(lang))
   }
 
   # Special case for Hong Kong and Macao, which should inherit Traditional
   # Chinese (zh_TW) before Simplified Chinese (zh_CN)
   if (lang %in% c("zh_HK", "zh_MO")) {
     zh_langs <- intersect(c("zh_TW", "zh_CN"), base_langs)
-    return(paste0(c(lang, zh_langs), collapse = ":"))
+    return(as_learnr_lang(paste0(c(lang, zh_langs), collapse = ":")))
   }
 
   # If `lang` is a variant of a language with a base R translation,
@@ -239,7 +268,7 @@ i18n_determine_base_r_language <- function(lang) {
     lang <- c(lang, base_lang_variants)
   }
 
-  paste(lang, collapse = ":")
+  as_learnr_lang(paste(lang, collapse = ":"))
 }
 
 i18n_get_language_option <- function() {

--- a/tests/testthat/helpers-i18n.R
+++ b/tests/testthat/helpers-i18n.R
@@ -1,0 +1,15 @@
+skip_if_lc_all_is_c <- function() {
+  # See rstudio/learnr#800
+  # Treat C.UTF-8 locale like C locale (BZ# 16621)
+  #
+  #  The wiki page https://sourceware.org/glibc/wiki/Proposals/C.UTF-8
+  #  says that "Setting LC_ALL=C.UTF-8 will ignore LANGUAGE just like it
+  #  does with LC_ALL=C." This patch implements it.
+
+  if (Sys.getenv("LC_ALL") == "C.UTF-8") {
+    skip("Skipping test because LC_ALL is C.UTF-8")
+  }
+  if (Sys.getenv("LC_ALL") == "C") {
+    skip("Skipping test because LC_ALL is C")
+  }
+}

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -205,6 +205,7 @@ test_that("i18n_span() returns an i18n span", {
 
 test_that("i18n_set_language_option() changes message language", {
   skip_if_not_pandoc("1.14")
+  skip_if_not(isTRUE(i18n_try_setenv_language("es")))
 
   withr::defer(i18n_set_language_option("en"))
 
@@ -234,6 +235,7 @@ test_that("i18n_set_language_option() changes message language", {
 
 test_that("i18n_set_language_option() sets up language inheritance", {
   skip_if_not_pandoc("1.14")
+  skip_if_not(isTRUE(i18n_try_setenv_language("es")))
 
   withr::defer(i18n_set_language_option("en"))
 
@@ -252,6 +254,8 @@ test_that("i18n_set_language_option() sets up language inheritance", {
   ex$tutorial$language <- "pt"
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$error_message, "objeto de tipo 'closure' não possível dividir em subconjuntos")
+
+  i18n_set_language_option("en")
 
   ex <- mock_exercise(
     user_code = "mean$x",

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -205,7 +205,6 @@ test_that("i18n_span() returns an i18n span", {
 
 test_that("i18n_set_language_option() changes message language", {
   skip_if_not_pandoc("1.14")
-  skip_if_not(isTRUE(i18n_try_setenv_language("es")))
 
   withr::defer(i18n_set_language_option("en"))
 
@@ -235,7 +234,6 @@ test_that("i18n_set_language_option() changes message language", {
 
 test_that("i18n_set_language_option() sets up language inheritance", {
   skip_if_not_pandoc("1.14")
-  skip_if_not(isTRUE(i18n_try_setenv_language("es")))
 
   withr::defer(i18n_set_language_option("en"))
 
@@ -254,8 +252,6 @@ test_that("i18n_set_language_option() sets up language inheritance", {
   ex$tutorial$language <- "pt"
   result <- evaluate_exercise(ex, new.env())
   expect_equal(result$error_message, "objeto de tipo 'closure' não possível dividir em subconjuntos")
-
-  i18n_set_language_option("en")
 
   ex <- mock_exercise(
     user_code = "mean$x",

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -205,6 +205,7 @@ test_that("i18n_span() returns an i18n span", {
 
 test_that("i18n_set_language_option() changes message language", {
   skip_if_not_pandoc("1.14")
+  skip_if_lc_all_is_c()
 
   withr::defer(i18n_set_language_option("en"))
 
@@ -234,6 +235,7 @@ test_that("i18n_set_language_option() changes message language", {
 
 test_that("i18n_set_language_option() sets up language inheritance", {
   skip_if_not_pandoc("1.14")
+  skip_if_lc_all_is_c()
 
   withr::defer(i18n_set_language_option("en"))
 


### PR DESCRIPTION
This PR simply skips checking that learnr can control the language used for R's messages in known scenarios where the `LANGUAGE` environment variable is ignored. Currently this is true for `LC_ALL="C"` and with newer versions of glibc also for `LC_ALL="C.UTF-8"`.

In an earlier iteration, I tried directly testing that if we are able to change the language of R message – by trying and succeeding or failing – but this create many more problems than it solved.

Fixes #800

Note that in the future we could maybe use `Sys.setLanguage()`, but this was added in R 4.2.0.