### PR TITLE
Ellipsis dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ BugReports: https://github.com/rstudio/learnr/issues
 Imports:
     checkmate,
     digest,
-    ellipsis (>= 0.2.0.1),
     evaluate,
     htmltools (>= 0.3.5),
     htmlwidgets,
@@ -47,7 +46,7 @@ Imports:
     promises,
     rappdirs,
     renv (>= 0.8.0),
-    rlang,
+    rlang (>= 1.0.0),
     rmarkdown (>= 1.12.0),
     rprojroot,
     shiny (>= 1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # learnr (development version)
 
+-   Removed dependency on ellipsis (@olivroy, #809)
 -   Added Norwegian translation contributed by @jonovik. (#806)
 
 # learnr 0.11.5

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -152,7 +152,7 @@ question <- function(
   initialize_tutorial()
 
   # capture/validate answers
-  ellipsis::check_dots_unnamed() # validate all answers are not named and not a misspelling
+  rlang::check_dots_unnamed() # validate all answers are not named and not a misspelling
   answers <- list(...)
   lapply(answers, function(answer) {
     checkmate::assert_class(answer, "tutorial_question_answer")

--- a/R/run.R
+++ b/R/run.R
@@ -47,7 +47,7 @@ run_tutorial <- function(
   clean = FALSE,
   as_rstudio_job = NULL
 ) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   checkmate::assert_character(name, any.missing = FALSE, max.len = 1, null.ok = TRUE)
   checkmate::assert_character(package, any.missing = FALSE, max.len = 1, null.ok = TRUE)
 


### PR DESCRIPTION
Just removing this dependency as it is being replaced by rlang.

PR task list:
- [x] Update NEWS
- [ ] Add tests (if possible)
- [ ] Update documentation with `devtools::document()`
