### PR TITLE
Slow down successive exercise execution via debounce

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # learnr (development version)
 
+-   Added option `tutorial.exercise.debounce` to slow down successive exercise execution (@internaut)
 -   Removed dependency on ellipsis (@olivroy, #809)
 -   Added Norwegian translation contributed by @jonovik. (#806)
 

--- a/R/exercise.R
+++ b/R/exercise.R
@@ -33,9 +33,13 @@ setup_exercise_handler <- function(exercise_rx, session) {
   # setup reactive values for return
   rv <- reactiveValues(triggered = 0, result = NULL)
 
+  # debounce option to slow down successive exercise execution requests
+  debounce_ms <- getOption("tutorial.exercise.debounce", 0)   # value in milliseconds
+  if (debounce_ms > 0)
+    exercise_rx <- debounce(exercise_rx, debounce_ms)
+
   # observe input
   observeEvent(exercise_rx(), {
-
     # get exercise from app
     exercise <- exercise_rx()
     # Add tutorial information

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -547,13 +547,11 @@ remove_knitr_hooks <- function() {
 
 exercise_server_chunk <- function(label) {
   # reactive for exercise execution
-  debounce_ms <- getOption("tutorial.exercise_debounce", 0)
-
   rmarkdown::shiny_prerendered_chunk('server', sprintf(
-'`tutorial-exercise-%s-result` <- learnr:::setup_exercise_handler(debounce(reactive(req(input$`tutorial-exercise-%s-code-editor`)), %d), session)
+'`tutorial-exercise-%s-result` <- learnr:::setup_exercise_handler(reactive(req(input$`tutorial-exercise-%s-code-editor`)), session)
 output$`tutorial-exercise-%s-output` <- renderUI({
   `tutorial-exercise-%s-result`()
-})', label, label, debounce_ms, label, label))
+})', label, label, label, label))
 }
 
 

--- a/R/knitr-hooks.R
+++ b/R/knitr-hooks.R
@@ -547,11 +547,13 @@ remove_knitr_hooks <- function() {
 
 exercise_server_chunk <- function(label) {
   # reactive for exercise execution
+  debounce_ms <- getOption("tutorial.exercise_debounce", 0)
+
   rmarkdown::shiny_prerendered_chunk('server', sprintf(
-'`tutorial-exercise-%s-result` <- learnr:::setup_exercise_handler(reactive(req(input$`tutorial-exercise-%s-code-editor`)), session)
+'`tutorial-exercise-%s-result` <- learnr:::setup_exercise_handler(debounce(reactive(req(input$`tutorial-exercise-%s-code-editor`)), %d), session)
 output$`tutorial-exercise-%s-output` <- renderUI({
   `tutorial-exercise-%s-result`()
-})', label, label, label, label))
+})', label, label, debounce_ms, label, label))
 }
 
 

--- a/pkgdown/assets/snippets/exercisedebounce.md
+++ b/pkgdown/assets/snippets/exercisedebounce.md
@@ -1,0 +1,2 @@
+# set debounce time to 1 second:
+options("tutorial.exercise.debounce" = 1000)

--- a/vignettes/articles/exercises.Rmd
+++ b/vignettes/articles/exercises.Rmd
@@ -80,6 +80,12 @@ This option can also be set either globally or per-chunk:
 insert_snippet("exerciseeval")
 ```
 
+It may be necessary to slow down successive exercise submissions, otherwise users may overwhelm your server by running exercise code chunks in fast repetition. You can do so globally by setting the option `tutorial.exercise.debounce` to an amount of time (in milliseconds) that is waited before the next code execution is performed:
+
+```{r snippet-exercisedebounce, echo = FALSE}
+insert_snippet("exercisedebounce")
+```
+
 ## Exercise Setup {#exercise-setup}
 
 Code chunks with `exercise=TRUE` are evaluated within standalone environments.


### PR DESCRIPTION
This adds a new option `tutorial.exercise.debounce`  to slow down successive exercise evaluations.

I've noticed that you can overwhelm a server that hosts a learnr tutorial by repeatedly clicking "Run Code" very quickly in an exercise chunk. On the Linux server that I'm using, this causes learnr to run a new R instance for each evaluation, amounting to hundreds or thousands of instances, depending on how quick you can click and how fast the server can execute and tear down again the R instances.

My fix introduces the use of [debounce()](https://rstudio.github.io/shiny/reference/debounce.html) when the option is active.

Use `options("tutorial.exercise.debounce" = 1000)` in a setup chunk of an Rmarkdown document to enable a debounce of 1 sec. The default value is 0, which keeps the behavior currently implemented in learnr (i.e. no debounce).

This is my first contribution here, I'm not quite sure if I've updated the documentation at the correct spot.

PR task list:
- [x] Update NEWS
- [x] Update documentation with `devtools::document()`
